### PR TITLE
Label runners created by module with `installation_id:XXXX-XXX-XXX-XXX`

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -30,4 +30,5 @@ module "record_metric" {
 
   lambda_bucket_name = aws_s3_bucket.lambda_tmp.bucket
   tags               = local.default_module_tags
+  installation_id    = random_uuid.installation-id.result
 }

--- a/modules/record_metric/lambda.tf
+++ b/modules/record_metric/lambda.tf
@@ -148,6 +148,7 @@ resource "aws_lambda_function" "lambda" {
       "GITHUB_SECRET" : var.github_credentials.secret,
       "GITHUB_SECRET_TYPE" : var.github_credentials.type,
       "GH_APP_ID" : var.github_app_id
+      "INSTALLATION_ID" : var.installation_id
     }
   }
   depends_on = [

--- a/modules/record_metric/lambda/main.py
+++ b/modules/record_metric/lambda/main.py
@@ -31,15 +31,15 @@ def lambda_handler(event, context):
     """
     LOG.info(f"{event = }")
     asg_name = environ["ASG_NAME"]
-    asg = ASG(asg_name=asg_name)
     github = GitHubAuth(
         _get_github_token(environ["GITHUB_ORG_NAME"]), environ["GITHUB_ORG_NAME"]
     )
     gha = GitHubActions(github)
 
     status_counts = Counter()
-    for instance in asg.instances:
-        runner = gha.find_runner_by_label(f"instance_id:{instance.instance_id}")
+    for runner in gha.find_runners_by_label(
+        f"installation_id:{environ['INSTALLATION_ID']}"
+    ):
         if runner and runner.status == "online":
             status_counts["busy" if runner.busy else "idle"] += 1
 

--- a/modules/record_metric/lambda/requirements.txt
+++ b/modules/record_metric/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.11
+infrahouse-core ~= 0.14

--- a/modules/record_metric/variables.tf
+++ b/modules/record_metric/variables.tf
@@ -32,6 +32,11 @@ variable "github_app_id" {
   description = "GitHub App that gives out GitHub tokens for Terraform. For instance, https://github.com/organizations/infrahouse/settings/apps/infrahouse-github-terraform"
 }
 
+variable "installation_id" {
+  description = "Unique identifier of runners created by the action-runner module. Each runner has a label 'installation_id:<installation_id>'."
+  type        = string
+}
+
 variable "lambda_bucket_name" {
   description = "S3 bucket to store lambda code"
   type        = string

--- a/modules/runner_deregistration/lambda.tf
+++ b/modules/runner_deregistration/lambda.tf
@@ -179,6 +179,7 @@ resource "aws_lambda_function" "lambda" {
       "GITHUB_SECRET" : var.github_credentials.secret,
       "GITHUB_SECRET_TYPE" : var.github_credentials.type,
       "GH_APP_ID" : var.github_app_id
+      "INSTALLATION_ID" : var.installation_id
     }
   }
   depends_on = [

--- a/modules/runner_deregistration/lambda/requirements.txt
+++ b/modules/runner_deregistration/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.12
+infrahouse-core ~= 0.14

--- a/modules/runner_deregistration/variables.tf
+++ b/modules/runner_deregistration/variables.tf
@@ -27,8 +27,9 @@ variable "github_app_id" {
   description = "GitHub App that gives out GitHub tokens for Terraform. For instance, https://github.com/organizations/infrahouse/settings/apps/infrahouse-github-terraform"
 }
 
-variable "hook_name" {
-  description = "Complete this lifecycle hook name after de-registration"
+variable "installation_id" {
+  description = "Unique identifier of runners created by the action-runner module. Each runner has a label 'installation_id:<installation_id>'."
+  type        = string
 }
 
 variable "lambda_bucket_name" {

--- a/registration.tf
+++ b/registration.tf
@@ -34,9 +34,9 @@ module "deregistration" {
   lambda_timeout                   = var.allowed_drain_time
   tags                             = local.default_module_tags
   python_version                   = var.python_version
-  hook_name                        = local.deregistration_hookname
   security_group_ids = [
     aws_security_group.actions-runner.id
   ]
-  subnet_ids = var.lambda_subnet_ids != null ? var.lambda_subnet_ids : var.subnet_ids
+  subnet_ids      = var.lambda_subnet_ids != null ? var.lambda_subnet_ids : var.subnet_ids
+  installation_id = random_uuid.installation-id.result
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pytest-infrahouse ~= 0.6
 pytest-timeout ~= 2.1
 pytest-rerunfailures ~= 12.0
 requests ~= 2.31
-infrahouse-core ~= 0.13
+infrahouse-core ~= 0.14


### PR DESCRIPTION
The deregistration lambda needs to know what runners where created by
the module. For that, it read the `installation_id:XXXX-XXX-XXX-XXX`
label.
