### PR TITLE
Upgrade infrahouse-core to 0.14.1

### DIFF
--- a/modules/record_metric/lambda/requirements.txt
+++ b/modules/record_metric/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.14
+infrahouse-core ~= 0.14, >= 0.14.1

--- a/modules/runner_deregistration/lambda/requirements.txt
+++ b/modules/runner_deregistration/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.14
+infrahouse-core ~= 0.14, >= 0.14.1

--- a/modules/runner_registration/lambda/requirements.txt
+++ b/modules/runner_registration/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.12
+infrahouse-core ~= 0.14, >= 0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pytest-infrahouse ~= 0.6
 pytest-timeout ~= 2.1
 pytest-rerunfailures ~= 12.0
 requests ~= 2.31
-infrahouse-core ~= 0.14
+infrahouse-core ~= 0.14, >= 0.14.1


### PR DESCRIPTION
This version optimizes response time of `GitHubActions().runners`
