### PR TITLE
Optimize ASG for fastest scale-out

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -36,7 +36,7 @@ resource "aws_autoscaling_policy" "scale_out" {
   name                   = "scale-out-idle-runners"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
-  cooldown               = 180
+  cooldown               = 0
   autoscaling_group_name = aws_autoscaling_group.actions-runner.name
   policy_type            = "SimpleScaling"
 }

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "aws_autoscaling_group" "actions-runner" {
   max_size                  = var.asg_max_size == null ? length(var.subnet_ids) + 1 : var.asg_max_size
   vpc_zone_identifier       = var.subnet_ids
   max_instance_lifetime     = var.max_instance_lifetime_days * 24 * 3600
-  health_check_grace_period = 60
+  health_check_grace_period = 0
   wait_for_capacity_timeout = "15m"
   dynamic "launch_template" {
     for_each = var.on_demand_base_capacity == null ? [1] : []
@@ -187,9 +187,9 @@ resource "aws_autoscaling_group" "actions-runner" {
     content {
       pool_state                  = "Hibernated"
       min_size                    = var.warm_pool_min_size != null ? var.warm_pool_min_size : var.idle_runners_target_count + 1
-      max_group_prepared_capacity = var.warm_pool_max_size != null ? var.warm_pool_max_size : var.idle_runners_target_count + 1
+      max_group_prepared_capacity = var.warm_pool_max_size != null ? var.warm_pool_max_size : var.asg_max_size
       instance_reuse_policy {
-        reuse_on_scale_in = true
+        reuse_on_scale_in = false
       }
     }
   }
@@ -227,6 +227,5 @@ resource "aws_autoscaling_lifecycle_hook" "terminating" {
   autoscaling_group_name = aws_autoscaling_group.actions-runner.name
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
   heartbeat_timeout      = 3600
-
-  default_result = "ABANDON"
+  default_result         = "ABANDON"
 }

--- a/modules/runner_registration/lambda/main.py
+++ b/modules/runner_registration/lambda/main.py
@@ -111,27 +111,12 @@ def _handle_bootstrap_hook(
     instance_id = asg_instance.instance_id
     asg = ASG(asg_name=asg_instance.asg_name)
     label = f"instance_id:{instance_id}"
-    LOG.info("Looking for runner with label %s", label)
+    LOG.info("Looking for runner with label %s.", label)
     runner = gha.find_runner_by_label(label)
     if runner:
         result = "CONTINUE"
         try:
-            LOG.info("Found runner %s", runner.name)
-            with timeout(wait_timeout):
-                exit_code = asg_instance.execute_command(
-                    "/usr/local/bin/puppet-wrapper", execution_timeout=900
-                )[0]
-            result = "CONTINUE" if exit_code == 0 else "ABANDON"
-
-        except (
-            ClientError,
-            BotoCoreError,
-            GithubException,
-            RuntimeError,
-            TimeoutError,
-        ) as err:
-            result = "ABANDON"
-            LOG.error(err)
+            LOG.info("Found runner %s in GitHub.", runner.name)
 
         finally:
             asg.complete_lifecycle_action(
@@ -144,7 +129,12 @@ def _handle_bootstrap_hook(
                 result,
             )
     else:
-        LOG.warning("Couldn't find a runner labeled %s", label)
+        LOG.warning(
+            "Couldn't find a runner labeled %s. "
+            "It can be OK if the runner is provisioning the first time. "
+            "Then, puppet will complete the bootstrap hook.",
+            label,
+        )
 
 
 def _get_github_token(org):


### PR DESCRIPTION
* Don't reuser runners. To prepare an instance for reuse, the lambdas
  had to stop the actions-runner service. Respecitvely, to bring it back
  to the ASG, the lambda had to start the service again and that took
  about 5 minutes which defeats the purpose of the warm pool.
* Set `health_check_grace_period` to zero. There is a bootstrap
  lifecycle hook which takes care of provisioning before the instance
  becomes `InService`.
* Don't wait for a next scale-out event. If Idle runners is zero - scale
  out.
