### PR TITLE
Add autoscaling_scaleout_evaluation_period. Remove the GitHub registration token sooner

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_metric_alarm" "idle_runners_low" {
   alarm_name          = "IdleRunnersTooLow-${aws_autoscaling_group.actions-runner.name}"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = 1
+  evaluation_periods  =  max(1, ceil(var.autoscaling_scaleout_evaluation_period / 60))
   metric_name         = "IdleRunners"
   namespace           = "GitHubRunners"
   period              = 60

--- a/modules/record_metric/lambda/requirements.txt
+++ b/modules/record_metric/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.14, >= 0.14.1
+infrahouse-core ~= 0.16, >= 0.16.1

--- a/modules/runner_deregistration/lambda.tf
+++ b/modules/runner_deregistration/lambda.tf
@@ -77,7 +77,8 @@ data "aws_iam_policy_document" "lambda-permissions" {
   }
   statement {
     actions = [
-      "secretsmanager:DeleteSecret"
+      "secretsmanager:DeleteSecret",
+      "secretsmanager:DescribeSecret"
     ]
     resources = [
       join(

--- a/modules/runner_deregistration/lambda/main.py
+++ b/modules/runner_deregistration/lambda/main.py
@@ -25,8 +25,13 @@ def lambda_handler(event, context):
         """
         This even is received when an instance is about to be terminated or when it's re-entering the warm pool.
         """
+        instance_id = event["detail"]["EC2InstanceId"]
+        gha.ensure_registration_token(
+            f"{environ['REGISTRATION_TOKEN_SECRET_PREFIX']}-{instance_id}",
+            present=False
+        )
         _handle_deregistration_hook(
-            HOOK_DEREGISTRATION, event["detail"]["EC2InstanceId"]
+            HOOK_DEREGISTRATION, instance_id
         )
     else:
         # Fall back to sweeping unused runners if no lifecycle hook is present

--- a/modules/runner_deregistration/lambda/requirements.txt
+++ b/modules/runner_deregistration/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.14, >= 0.14.1
+infrahouse-core ~= 0.16, >= 0.16.1

--- a/modules/runner_registration/lambda/main.py
+++ b/modules/runner_registration/lambda/main.py
@@ -77,7 +77,11 @@ def _handle_registration_hook(
     try:
         registration_token_secret_prefix = environ["REGISTRATION_TOKEN_SECRET_PREFIX"]
         registration_token_secret = f"{registration_token_secret_prefix}-{instance_id}"
-        gha.ensure_registration_token(registration_token_secret)
+        # if the instance is already registered, we don't need the token
+        gha.ensure_registration_token(
+            registration_token_secret,
+            present=gha.find_runner_by_label(f"instance_id:{instance_id}") is None,
+        )
         asg.complete_lifecycle_action(hook_name=hook_name, instance_id=instance_id)
         LOG.info(
             f"Lifecycle hook %s for %s is successfully complete.",

--- a/modules/runner_registration/lambda/requirements.txt
+++ b/modules/runner_registration/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.14, >= 0.14.1
+infrahouse-core ~= 0.16, >= 0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 black ~= 25.1
 boto3 ~= 1.26
 botocore ~= 1.31
-infrahouse-toolkit ~= 2.9, >= 2.9.7
+infrahouse-toolkit ~= 2.54
 myst-parser ~= 2.0
 pytest ~= 8.3
 pytest-infrahouse ~= 0.6
 pytest-timeout ~= 2.1
 pytest-rerunfailures ~= 12.0
 requests ~= 2.31
-infrahouse-core ~= 0.14, >= 0.14.1
+infrahouse-core ~= 0.16, >= 0.16.1

--- a/variables.tf
+++ b/variables.tf
@@ -21,10 +21,17 @@ variable "asg_max_size" {
   type        = number
   default     = null
 }
+
 variable "autoscaling_step" {
   description = "How many instances to add or remove when the autoscaling policy is triggered."
   type        = number
   default     = 1
+}
+
+variable "autoscaling_scaleout_evaluation_period" {
+  description = "The duration, in seconds, that the autoscaling policy will evaluate the scaling conditions before executing a scale-out action. This period helps to prevent unnecessary scaling by allowing time for metrics to stabilize after fluctuations. Default value is 60 seconds."
+  type        = number
+  default     = 60
 }
 
 variable "cloudwatch_log_group_retention" {


### PR DESCRIPTION
Before, the ASG waited a hardcoded one minute before scaling out. Add a
variable `autoscaling_scaleout_evaluation_period` with the default of 60
seconds to tune this. It's useful for sporadic short-lived jobs. We
don't want to launch an instance when it won't be needed anyway.

As soon as a runner is registered, the registration token is not needed.
The lambda functions will try to remove it.

* The registration lambda will remove the token when the runner is
  known. This can happen when the instance comes from hibernation.

* The deregistration lambda will delete the token if it's still around.
