### PR TITLE
Upgrade cloud-init to 2.0.0

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -56,17 +56,12 @@ data "aws_iam_policy_document" "required_permissions" {
   }
 }
 
-locals {
-  ami_name_pattern = contains(
-    ["focal", "jammy"], var.ubuntu_codename
-  ) ? "ubuntu/images/hvm-ssd/ubuntu-${var.ubuntu_codename}-*" : "ubuntu/images/hvm-ssd-gp3/ubuntu-${var.ubuntu_codename}-*"
-}
-data "aws_ami" "ubuntu" {
+data "aws_ami" "ubuntu_pro" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = [local.ami_name_pattern]
+    values = [local.ami_name_pattern_pro]
   }
 
   filter {

--- a/locals.tf
+++ b/locals.tf
@@ -8,8 +8,9 @@ locals {
     },
     var.tags
   )
+  ami_name_pattern_pro = "ubuntu-pro-server/images/hvm-ssd-gp3/ubuntu-${var.ubuntu_codename}-*"
 
-  ami_id                           = var.ami_id == null ? data.aws_ami.ubuntu.id : var.ami_id
+  ami_id                           = var.ami_id == null ? data.aws_ami.ubuntu_pro.id : var.ami_id
   registration_token_secret_prefix = "GH-reg-token-${random_string.reg_token_suffix.result}"
   registration_hookname            = "registration"
   deregistration_hookname          = "deregistration"

--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,9 @@ module "instance-profile" {
 }
 
 module "userdata" {
-  source                   = "registry.infrahouse.com/infrahouse/cloud-init/aws"
-  version                  = "1.18.0"
+  source  = "registry.infrahouse.com/infrahouse/cloud-init/aws"
+  version = "2.0.0"
+
   environment              = var.environment
   role                     = "gha_runner"
   puppet_debug_logging     = var.puppet_debug_logging

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -18,7 +18,7 @@ from tests.conftest import (
 
 @pytest.mark.parametrize(
     "secret_type, ubuntu_codename",
-    [("token", "jammy"), ("pem", "jammy"), ("pem", "noble"), ("pem", "oracular")],
+    [("token", "noble"), ("pem", "noble"), ("pem", "oracular")],
 )
 def test_module(
     service_network,


### PR DESCRIPTION
The 2.0.0 version handles InfraHouse AMI with a baked in APT repository.

Use Ubuntu Pro by default.