### PR TITLE
fix: warm_pool_max null when asg_max_size is unset

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -22,7 +22,8 @@ locals {
   instance_memory_gb = ceil(data.aws_ec2_instance_type.this.memory_size / 1024.0)
   # Extra space on root volume for OS, packages, and swap beyond what hibernation needs for RAM
   hibernation_volume_overhead_gb = 10
-  warm_pool_max                  = var.warm_pool_max_size != null ? var.warm_pool_max_size : var.asg_max_size
+  asg_max                        = var.asg_max_size != null ? var.asg_max_size : length(var.subnet_ids) + 1
+  warm_pool_max                  = var.warm_pool_max_size != null ? var.warm_pool_max_size : local.asg_max
   # +1 ensures at least one pre-warmed instance is always available during scale-out
   warm_pool_min = min(
     var.warm_pool_min_size != null ? var.warm_pool_min_size : var.idle_runners_target_count + 1,

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ locals {
 resource "aws_autoscaling_group" "actions-runner" {
   name                      = local.asg_name
   min_size                  = var.asg_min_size == null ? length(var.subnet_ids) : var.asg_min_size
-  max_size                  = var.asg_max_size == null ? length(var.subnet_ids) + 1 : var.asg_max_size
+  max_size                  = local.asg_max
   vpc_zone_identifier       = var.subnet_ids
   max_instance_lifetime     = var.max_instance_lifetime_days * 24 * 3600
   health_check_grace_period = 0


### PR DESCRIPTION
## Summary

- Fixes a crash when `asg_max_size` is left at its default (`null`) — `local.warm_pool_max` resolved to null and `min()` in `warm_pool_min` failed with `"argument must not be null"`.

## Root cause

`warm_pool_max` fell through to `var.asg_max_size` which is null by default. The ASG resource computed the fallback (`length(var.subnet_ids) + 1`) inline, but the locals didn't. Terraform evaluates all locals eagerly, so even when the warm pool block is disabled via `on_demand_base_capacity`, the null still blows up.

## Fix

- Extract `local.asg_max` with the same `length(var.subnet_ids) + 1` fallback.
- Chain `warm_pool_max` off `local.asg_max` instead of `var.asg_max_size`.
- Deduplicate `main.tf` to use `local.asg_max`.

## Test plan

- [ ] `terraform plan` succeeds with `asg_max_size` unset and `on_demand_base_capacity = 0` (the failing config).
- [ ] `make test-clean` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)