### PR TITLE
fix: bump infrahouse-core to ~= 1.0 to reduce Lambda memory pressure

### DIFF
--- a/modules/record_metric/lambda/main.py
+++ b/modules/record_metric/lambda/main.py
@@ -4,8 +4,6 @@ from os import environ
 
 from infrahouse_core.timeout import timeout
 
-from infrahouse_core.aws.asg import ASG
-
 from infrahouse_core.github import get_tmp_token, GitHubAuth, GitHubActions
 
 from infrahouse_core.aws import get_secret

--- a/modules/record_metric/lambda/requirements.txt
+++ b/modules/record_metric/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.17
+infrahouse-core ~= 1.0

--- a/modules/runner_deregistration/lambda/requirements.txt
+++ b/modules/runner_deregistration/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.17
+infrahouse-core ~= 1.0

--- a/modules/runner_registration/lambda/requirements.txt
+++ b/modules/runner_registration/lambda/requirements.txt
@@ -1,1 +1,1 @@
-infrahouse-core ~= 0.17
+infrahouse-core ~= 1.0


### PR DESCRIPTION
## Summary
- Bumps `infrahouse-core` from `~= 0.17` to `~= 1.0` in all three Lambda `requirements.txt` files (`record_metric`, `runner_registration`, `runner_deregistration`).
- Removes an unused `from infrahouse_core.aws.asg import ASG` import in `record_metric/lambda/main.py`.

## Why
All three Lambdas have been repeatedly tripping the 80% memory-utilization alarm on their 256 MB allocation. `infrahouse-core` 1.0.0 makes `GitHubActions.runners` and `GitHubActions.find_runners_by_label()` lazy iterators instead of materializing the full org runner list. Memory usage is now bounded to a single GitHub API page instead of scaling linearly with total org runner count.

Root cause and the long-term fix are tracked in infrahouse/infrahouse-core#136.

## Compatibility audit
The v1.0.0 release notes document one breaking change: `runners` and `find_runners_by_label()` now return `Iterator` instead of `List`. Code that iterates with `for ... in ...` is unaffected; code using `len()`, indexing, or `== []` would need `list()` wrapping.

All call sites consume the result exactly once in a plain `for` loop — no wrapping needed:

| File | Call site | Pattern |
|---|---|---|
| `modules/record_metric/lambda/main.py:40` | `find_runners_by_label` | `for runner in ...` ✓ |
| `modules/runner_registration/lambda/main.py:81, 117` | `find_runner_by_label` (singular, unchanged) | ✓ |
| `modules/runner_deregistration/lambda/main.py:87` | `find_runners_by_label` | `for runner in ...` ✓ |

## Test plan
- [ ] CI tests pass (`terraform-CD.yml`)
- [ ] After deploy, watch `LambdaInsights/memory_utilization` Maximum for all three functions over a 1-hour window
- [ ] Confirm the three memory alarms (`*_record_metric-memory`, `*_registration-memory`, `*_deregistration-memory`) stay in `OK` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)