### PR TITLE
fix: raise Lambda memory to 512 MB and hoist boto3 clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ terraform.tfstate*
 .terraform
 __pycache__
 *.zip
+/**/.build/
 terraform.tfvars
 .terraform.tfstate.lock.info
 pytest-*-output.log

--- a/modules/record_metric/lambda/main.py
+++ b/modules/record_metric/lambda/main.py
@@ -13,6 +13,12 @@ import boto3
 LOG = logging.getLogger()
 LOG.setLevel(level=logging.INFO)
 
+# Module-scope boto3 clients: created once at cold start so the ~8 MB
+# botocore endpoints.json parse runs during INIT (uncapped CPU) instead of
+# inside the handler's SIGALRM-bounded timeout window.
+_secretsmanager = boto3.client("secretsmanager")
+_cloudwatch = boto3.client("cloudwatch")
+
 
 def lambda_handler(event, context):
     """
@@ -43,9 +49,7 @@ def lambda_handler(event, context):
 
     LOG.info(f"{status_counts['idle'] = }, {status_counts['busy'] = }")
 
-    # Send the custom metric
-    cloudwatch = boto3.client("cloudwatch")
-    cloudwatch.put_metric_data(
+    _cloudwatch.put_metric_data(
         Namespace="GitHubRunners",
         MetricData=[
             {
@@ -71,7 +75,7 @@ def lambda_handler(event, context):
 def _get_github_token(org):
     with timeout(5):
         return (
-            get_secret(boto3.client("secretsmanager"), environ["GITHUB_SECRET"])
+            get_secret(_secretsmanager, environ["GITHUB_SECRET"])
             if environ["GITHUB_SECRET_TYPE"] == "token"
             else get_tmp_token(int(environ["GH_APP_ID"]), environ["GITHUB_SECRET"], org)
         )

--- a/modules/record_metric/main.tf
+++ b/modules/record_metric/main.tf
@@ -61,7 +61,7 @@ module "lambda_monitored" {
   architecture                         = var.architecture
   python_version                       = var.python_version
   timeout                              = var.lambda_timeout
-  memory_size                          = 256
+  memory_size                          = 512
   memory_utilization_threshold_percent = 80
   cloudwatch_log_retention_days        = var.cloudwatch_log_group_retention
   alarm_emails                         = var.alarm_emails

--- a/modules/runner_deregistration/lambda/main.py
+++ b/modules/runner_deregistration/lambda/main.py
@@ -11,6 +11,13 @@ from infrahouse_core.aws.asg import ASG
 LOG = logging.getLogger()
 LOG.setLevel(level=logging.INFO)
 
+# Module-scope boto3 session: created once at cold start so the ~8 MB
+# botocore endpoints.json parse runs during INIT (uncapped CPU) instead of
+# inside the handler. Passed explicitly to every ASGInstance / ASG so all
+# AWS clients share a single credential chain and endpoint cache.
+_session = boto3.Session()
+_secretsmanager = _session.client("secretsmanager")
+
 HOOK_DEREGISTRATION = "deregistration"
 
 
@@ -37,8 +44,8 @@ def lambda_handler(event, context):
 
 
 def _handle_deregistration_hook(hook_name, instance_id):
-    asg_instance = ASGInstance(instance_id=instance_id)
-    asg = ASG(asg_name=asg_instance.asg_name)
+    asg_instance = ASGInstance(instance_id=instance_id, session=_session)
+    asg = ASG(asg_name=asg_instance.asg_name, session=_session)
     result = "ABANDON"
     try:
         if asg_instance.lifecycle_state == "Warmed:Terminating:Wait":
@@ -69,7 +76,7 @@ def _handle_deregistration_hook(hook_name, instance_id):
 
 def _get_github_token(org):
     return (
-        get_secret(boto3.client("secretsmanager"), environ["GITHUB_SECRET"])
+        get_secret(_secretsmanager, environ["GITHUB_SECRET"])
         if environ["GITHUB_SECRET_TYPE"] == "token"
         else get_tmp_token(int(environ["GH_APP_ID"]), environ["GITHUB_SECRET"], org)
     )
@@ -87,7 +94,10 @@ def _clean_runners(gha: GitHubActions, installation_id: str):
     for runner in gha.find_runners_by_label(f"installation_id:{installation_id}"):
         LOG.info("Found runner %s", runner.name)
         try:
-            if ASGInstance(instance_id=runner.instance_id).state == "terminated":
+            if (
+                ASGInstance(instance_id=runner.instance_id, session=_session).state
+                == "terminated"
+            ):
                 LOG.info(
                     "Instance %s is terminated. Will deregister the runner %s.",
                     runner.instance_id,

--- a/modules/runner_deregistration/main.tf
+++ b/modules/runner_deregistration/main.tf
@@ -97,7 +97,7 @@ module "lambda_monitored" {
   architecture                         = var.architecture
   python_version                       = var.python_version
   timeout                              = var.lambda_timeout
-  memory_size                          = 256
+  memory_size                          = 512
   memory_utilization_threshold_percent = 80
   cloudwatch_log_retention_days        = var.cloudwatch_log_group_retention
   alarm_emails                         = var.alarm_emails

--- a/modules/runner_registration/lambda/main.py
+++ b/modules/runner_registration/lambda/main.py
@@ -13,6 +13,13 @@ from github import GithubException
 LOG = logging.getLogger()
 LOG.setLevel(level=logging.INFO)
 
+# Module-scope boto3 session: created once at cold start so the ~8 MB
+# botocore endpoints.json parse runs during INIT (uncapped CPU) instead of
+# inside the handler. Passed explicitly to every ASGInstance / ASG so all
+# AWS clients share a single credential chain and endpoint cache.
+_session = boto3.Session()
+_secretsmanager = _session.client("secretsmanager")
+
 HOOK_REGISTRATION = "registration"
 HOOK_BOOTSTRAP = "bootstrap"
 
@@ -35,7 +42,9 @@ def lambda_handler(event, context):
     LOG.info(f"{event = }")
     hook_name = event["detail"]["LifecycleHookName"]
     LOG.info(f"{hook_name = }")
-    asg_instance = ASGInstance(instance_id=event["detail"]["EC2InstanceId"])
+    asg_instance = ASGInstance(
+        instance_id=event["detail"]["EC2InstanceId"], session=_session
+    )
     github = GitHubAuth(
         _get_github_token(environ["GITHUB_ORG_NAME"]), environ["GITHUB_ORG_NAME"]
     )
@@ -70,7 +79,7 @@ def lambda_handler(event, context):
 def _handle_registration_hook(
     asg_instance: ASGInstance, hook_name: str, gha: GitHubActions
 ):
-    asg = ASG(asg_name=asg_instance.asg_name)
+    asg = ASG(asg_name=asg_instance.asg_name, session=_session)
     instance_id = asg_instance.instance_id
     try:
         registration_token_secret_prefix = environ["REGISTRATION_TOKEN_SECRET_PREFIX"]
@@ -111,7 +120,7 @@ def _handle_bootstrap_hook(
     asg_instance: ASGInstance, hook_name: str, gha: GitHubActions, wait_timeout=900
 ):
     instance_id = asg_instance.instance_id
-    asg = ASG(asg_name=asg_instance.asg_name)
+    asg = ASG(asg_name=asg_instance.asg_name, session=_session)
     label = f"instance_id:{instance_id}"
     LOG.info("Looking for runner with label %s.", label)
     runner = gha.find_runner_by_label(label)
@@ -141,7 +150,7 @@ def _handle_bootstrap_hook(
 
 def _get_github_token(org):
     return (
-        get_secret(boto3.client("secretsmanager"), environ["GITHUB_SECRET"])
+        get_secret(_secretsmanager, environ["GITHUB_SECRET"])
         if environ["GITHUB_SECRET_TYPE"] == "token"
         else get_tmp_token(int(environ["GH_APP_ID"]), environ["GITHUB_SECRET"], org)
     )

--- a/modules/runner_registration/main.tf
+++ b/modules/runner_registration/main.tf
@@ -104,7 +104,7 @@ module "lambda_monitored" {
   architecture                         = var.architecture
   python_version                       = var.python_version
   timeout                              = var.lambda_timeout
-  memory_size                          = 256
+  memory_size                          = 512
   memory_utilization_threshold_percent = 80
   cloudwatch_log_retention_days        = var.cloudwatch_log_group_retention
   alarm_emails                         = var.alarm_emails

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest-infrahouse ~= 0.24, >= 0.24.1
-infrahouse-core ~= 0.24, >= 0.17.2
+infrahouse-core ~= 1.0
 
 # Documentation dependencies
 diagrams ~= 0.25

--- a/test_data/actions-runner/.gitignore
+++ b/test_data/actions-runner/.gitignore
@@ -1,0 +1,1 @@
+terraform.tf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def ensure_runners(
         with timeout(timeout_time):
             while True:
                 try:
-                    runners = gha.find_runners_by_label("awesome")
+                    runners = list(gha.find_runners_by_label("awesome"))
                     LOG.info("Found %d runners", len(runners))
                     assert len(runners) > 0
 


### PR DESCRIPTION
## Summary

- **Raise `memory_size` from 256 MB to 512 MB** in all three sub-module lambdas (`record_metric`, `runner_registration`, `runner_deregistration`). At 256 MB they were hitting CloudWatch memory alarms. Diagnostic tracing showed the steady-state working set is ~73 MB Python + ~83 MB `cloudwatch_lambda_agent` extension ≈ 156 MB; 512 MB gives 3× headroom.
- **Hoist every boto3 client to module scope** and share a single `boto3.Session()` across every `ASGInstance` / `ASG` construction (both already accept `session=`). The ~8 MB `botocore/endpoints.json` parse now runs once during INIT (uncapped CPU) instead of on each warm invocation. In `record_metric` this fixes a latent cold-start bug where the parse was running *inside* a SIGALRM-bounded `timeout(5)` context.
- **Upgrade `requirements.txt` to `infrahouse-core ~= 1.0`** and wrap `find_runners_by_label()` in `list(...)` at `tests/conftest.py:68` so `len()` / indexing keeps working against the new iterator API. The Lambda `requirements.txt` files were already bumped to `~= 1.0` in #89.

## Diagnostic evidence

Measured on the clean fix with module-scope clients, 14 consecutive warm invocations on the same container:

| inv | rss MiB | traced MiB | gc_objects |
|-----|---------|-----------|------------|
| 1   | 70.7 | 0.1 | 86 771 |
| 2   | 72.2 | 0.2 | 87 413 |
| 3   | 73.0 | 0.2 | 89 467 |
| 4   | 73.3 | 0.2 | 87 364 |
| 5   | 73.5 | 0.2 | 90 097 |
| 6–14 | **73.5 (flat)** | 0.2 | 88k–90k oscillation |

`traced_current` is rock-solid at 0.2 MiB and `gc_objects` shows no monotonic trend — **no leak**. The ~3 MiB ramp over the first 5 calls is normal glibc arena warm-up, then a clean plateau.

## Test plan

- [ ] `make lint` passes
- [ ] `make test-keep` passes (both `test_module` and the migration tests)
- [ ] Lambda Insights `memory_utilization` for all three functions stays under 70% on the test ASG
- [ ] No `Status: timeout` entries in `/aws/lambda/*_record_metric` logs after deploy
- [ ] CloudWatch memory alarms for the three lambdas remain silent for 24h post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)