### PR TITLE
feat: alarms + CloudWatch dashboard; docs sidebar fix (#93, #79)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,3 +11,7 @@ replace = version = "{new_version}"
 [bumpversion:file:locals.tf]
 search = module_version = "{current_version}"
 replace = module_version = "{new_version}"
+
+[bumpversion:file:docs/examples.md]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.claude/plans/alarms-and-dashboard.md
+++ b/.claude/plans/alarms-and-dashboard.md
@@ -1,0 +1,383 @@
+# Plan: Alarms UX fix + docs sidebar + examples page
+
+Tracking: https://github.com/infrahouse/terraform-aws-actions-runner/issues/93
+Also closes the docs-site sidebar regression and completes the remaining
+docs work from https://github.com/infrahouse/terraform-aws-actions-runner/issues/79.
+
+## Background
+
+This PR bundles two pieces of work:
+
+1. **Docs site regression (already staged locally).** `mkdocs.yml` only had
+   `Home: index.md` in `nav`, so the MkDocs Material sidebar rendered with
+   no entries even though 8 other pages existed on disk. Also, `docs/examples.md`
+   (required by issue #79) was missing.
+2. **Alarms UX bug (issue #93).** The CPU CloudWatch alarm in
+   `cloudwatch.tf:1` is gated strictly on `var.sns_topic_alarm_arn != null`.
+   Callers who set only `alarm_emails` (the documented alert channel) silently
+   get no CPU alarm. A compliance auditor flagged EC2s created by this module
+   as unmonitored; the module's own contract told the operator they *were*
+   monitored.
+
+The two pieces are shipping together because (a) the docs changes are already
+made locally on `main` and should land in the next PR, and (b) the fix for #93
+requires README + `docs/monitoring.md` updates that naturally belong with a
+docs-focused change.
+
+## Confirmed RCA for #93
+
+`cloudwatch.tf:2` — `count = var.sns_topic_alarm_arn != null ? 1 : 0`.
+
+`variables.tf:54-61` — `alarm_emails` is required and validated
+(`length > 0`), and is correctly wired into the submodules
+(`record_metric`, `runner_deregistration`, `runner_registration`) for Lambda
+error monitoring via `terraform-aws-lambda-monitored`.
+
+But the root-module CPU alarm is on a completely different channel
+(`sns_topic_alarm_arn`), which is **optional and defaults to `null`**
+(`variables.tf:256-260`). Result: the two advertised notification paths are
+disjoint. Lambda errors → `alarm_emails`. EC2 CPU → `sns_topic_alarm_arn`.
+An operator setting one has no indication the other is silently inactive.
+
+## Strategy
+
+Adopt the pattern already established in `terraform-aws-lambda-monitored`:
+
+- `alarm_emails` is **required** and non-empty (validated). It is the
+  load-bearing notification channel.
+- The module **always creates its own SNS topic** and subscribes the emails
+  to it. No conditional-creation gymnastics, no `count = 0` paths.
+- External SNS topics are **permitted but optional** via an
+  `alarm_topic_arns` list (default `[]`), for callers who want to fan out
+  to PagerDuty/Slack/shared org topics in addition to email.
+- All alarms send to the union: `[own_topic] + alarm_topic_arns`.
+
+Then expand coverage and ship a dashboard so operators have one pane of glass
+— which is what the "alarms and dashboards story" in #93 actually asks for.
+
+### Breaking change: `sns_topic_alarm_arn` → `alarm_topic_arns`
+
+The current singular `var.sns_topic_alarm_arn` (optional, default `null`) is
+replaced by plural `var.alarm_topic_arns` (list, default `[]`). This is the
+clean break — no shim, no back-compat alias. Noted in CHANGELOG under
+`BREAKING CHANGES`.
+
+`alarm_emails` remains **required** and non-empty (`length > 0` validation
+stays). The module guarantees every operator has at least one working
+notification path; `alarm_topic_arns` is purely additive fan-out.
+
+Semver: **major bump** (`3.5.0` → `4.0.0`). We maintain strict semver
+discipline — a caller-visible variable rename is a breaking change regardless
+of how mechanical the migration is.
+
+## Scope
+
+### Part A — docs sidebar + examples page (already done locally, will be in this PR)
+
+- [x] `mkdocs.yml:37-47` — add all 9 pages to `nav`.
+- [x] `docs/examples.md` — new page with 6 patterns (token auth, GitHub App,
+      spot + on-demand floor, warm pool, labels/large instances, multi-pool).
+- [ ] Cross-check variable names used in `docs/examples.md`
+      (`warm_pool_min_size`, `warm_pool_max_size`, `on_demand_base_capacity`,
+      `extra_labels`, `asg_min_size`, `asg_max_size`) against `variables.tf`
+      before commit. Rename or drop any that don't match.
+
+### Part B — alarms UX (#93)
+
+**B1. Always create SNS topic; subscribe required `alarm_emails`; accept optional external topics.**
+
+New `alarms.tf` (keeps `cloudwatch.tf` focused on metric alarms):
+
+```hcl
+resource "aws_sns_topic" "alarms" {
+  name = "${aws_autoscaling_group.actions-runner.name}-alarms"
+  tags = local.default_module_tags
+}
+
+resource "aws_sns_topic_subscription" "alarm_emails" {
+  for_each  = toset(var.alarm_emails)
+  topic_arn = aws_sns_topic.alarms.arn
+  protocol  = "email"
+  endpoint  = each.value
+}
+
+locals {
+  all_alarm_topic_arns = concat(
+    [aws_sns_topic.alarms.arn],
+    var.alarm_topic_arns,
+  )
+}
+```
+
+Variable changes in `variables.tf`:
+
+- `alarm_emails` — **keep** as-is (already `list(string)`, already validated
+  `length > 0`).
+- **Remove** `sns_topic_alarm_arn` (singular, optional string).
+- **Add** `alarm_topic_arns` — `list(string)`, default `[]`, for external
+  fan-out targets (PagerDuty/Slack/shared org topics).
+
+Then in `cloudwatch.tf`:
+
+- `count` gating on `sns_topic_alarm_arn` goes away — alarms are always on.
+- `alarm_actions = local.all_alarm_topic_arns` (list, so email + external
+  topics both fire).
+
+Naming caveat: the ASG name is computed and so is the topic name — matches
+how the record_metric/deregistration Lambdas name their resources.
+
+**B2. Validation — fail fast instead of silent drop.**
+
+`alarm_emails` already has `length > 0` validation. No change needed there —
+the bug wasn't validation, it was the CPU alarm ignoring the variable. After
+B1, there is no silent-drop path to validate against.
+
+**B3. Expand alarm coverage.**
+
+Additions in `cloudwatch.tf`, all with `alarm_actions = local.all_alarm_topic_arns`.
+
+**ASG count metrics** (`AWS/AutoScaling`, dimension `AutoScalingGroupName`):
+
+- **Total instance count** — alarm on `GroupInServiceInstances` hitting
+  `var.asg_max_size` sustained for N minutes. Signals the ASG is pinned at
+  max (saturation) — either raise the ceiling or investigate stuck jobs.
+- **Zero in-service instances** — alarm on `GroupInServiceInstances == 0`
+  when `GroupDesiredCapacity > 0`. Catastrophic; should never sit there.
+- **Warm pool depletion** — conditional on warm pool enabled. Alarm on
+  `WarmPoolWarmedCapacity == 0` for sustained period when
+  `WarmPoolDesiredCapacity > 0`. The whole point of the warm pool is
+  latency hiding; if it's empty, the optimization is off.
+- **Pending stuck** — `GroupPendingInstances > 0` sustained for **>20 min**.
+  Puppet provisioning can legitimately run up to ~15 min on cold boot, so
+  the threshold sits above that ceiling to avoid false alarms during normal
+  scale-out. Beyond 20 min, something is genuinely stuck (bad LT, capacity
+  issues, IAM). CloudWatch doesn't expose a ready-made "launch failure
+  count" metric, so this is our proxy.
+
+**Custom `GitHubRunners` metrics** (from `record_metric/lambda/main.py:52`,
+namespace `GitHubRunners`, dimension `asg_name`):
+
+- **Registration gap** — metric-math alarm on
+  `GroupInServiceInstances - (BusyRunners + IdleRunners) > 0` sustained for
+  **>5 min**. Catches the "EC2 is InService but never registered as a
+  runner" bug class — exactly the class #93 is about. Timing rationale: the
+  ASG only marks an instance InService after the Launch lifecycle hook
+  completes (which runs runner_registration Lambda), so by the time an
+  instance is InService it should already be a GitHub runner. A 5-min
+  sustained gap gives headroom for `record_metric`'s 1-min sampling cadence
+  plus GitHub API propagation. Most valuable single new alarm in this plan.
+- **BusyRunners saturation** — alarm on `BusyRunners == GroupInServiceInstances`
+  sustained for >N minutes with `GroupInServiceInstances == asg_max_size`.
+  Means the fleet is 100% busy at max size — jobs are queueing. Distinct
+  from the scale-out signal, because scale-out triggers on `IdleRunners`;
+  once we're at max capacity, scale-out can't help and operators need to
+  know.
+- **IdleRunners flatline** — do **not** add. It's redundant with the
+  existing `IdleRunnersLow` / `IdleRunnersTooHigh` alarms that drive
+  scale-out/scale-in; a third alarm on the same metric creates noise.
+
+**Host-level (CloudWatch agent-dependent)**:
+
+Confirmed: `profile::github_runner` does **not** include
+`profile::cloudwatch_agent` (verified in
+`puppet-code/modules/profile/manifests/github_runner.pp` and
+`profile/manifests/base.pp`). The agent manifest exists in puppet-code but
+is only wired into `terraformer`, `openvpn_server`, and `jumphost` roles.
+So host-level metrics are **not available by default** on runners.
+
+**Decision: defer host-level alarms entirely to a follow-up PR.**
+
+Tracked in puppet-code: https://github.com/infrahouse/puppet-code/issues/270
+(add `profile::cloudwatch_agent` to `role::github_runner`).
+
+This PR ships **no** host-level alarms. When infrahouse/puppet-code#270
+lands and the CloudWatch agent is guaranteed on runners, a follow-up PR in
+this module will add `disk_used_percent` (path=/) > 85% and
+`mem_used_percent` > 85% alarms **unconditionally** — no `enable_*`
+variables, no opt-in toggles. Same pattern as every other alarm in this
+module: monitored-by-default.
+
+Rationale for dropping the opt-in flags: consistent with the standing
+preference to avoid configuration variables for hypothetical needs. An
+opt-in flag here would exist solely to bridge a brief window before the
+puppet fix lands; not worth the permanent API surface.
+
+Note in `docs/monitoring.md`: mention that host alarms will be added once
+the agent is available; callers who can't wait can install the agent via
+`post_runcmd` / custom `puppet_manifest` and use their own alarms.
+
+**Already covered, don't duplicate**:
+
+- **Lambda errors** — handled by `terraform-aws-lambda-monitored` in each
+  submodule (`record_metric`, `runner_registration`, `runner_deregistration`).
+  All three already receive `alarm_emails`. Just document in
+  `docs/monitoring.md` so operators know it's covered.
+
+(Resolved: Puppet does not install the CloudWatch agent on
+`role::github_runner` today. See "Host-level" section above for opt-in
+design and the follow-up path.)
+
+**B4. CloudWatch dashboard.**
+
+One pane of glass — always on, not opt-in. The whole point of the plan is
+"this module is monitored by default." If a caller standardizes on Grafana
+and doesn't want the AWS dashboard, we revisit with an `enable_dashboard`
+variable at that time; we don't pre-gate for a hypothetical.
+
+Single `aws_cloudwatch_dashboard` resource in a new `dashboard.tf`, named
+`"${aws_autoscaling_group.actions-runner.name}"` (same deterministic pattern
+as the SNS topic). JSON body built via `jsonencode(...)`. Region injected
+from `data.aws_region.current.name`.
+
+Rows, top-to-bottom — ordered by how often an operator scans them:
+
+1. **Alarms — what's firing now.** Alarm-status widget listing every
+   `aws_cloudwatch_metric_alarm` this module owns (CPU, unhealthy hosts,
+   disk/memory if enabled, `IdleRunnersLow`, `IdleRunnersTooHigh`, and the
+   Lambda error alarms from the three submodules via
+   `terraform-aws-lambda-monitored`). Top row because a green row means you
+   scroll past; a red row is why you opened the dashboard.
+
+2. **Runner supply & demand.** Custom metrics already emitted in the
+   `GitHubRunners` namespace by `record_metric/lambda/main.py:52`:
+   - `BusyRunners` + `IdleRunners` — stacked area, per `asg_name` dimension.
+   - Utilization ratio `BusyRunners / (BusyRunners + IdleRunners)` — metric math.
+   - Forward-compat slot for `QueuedJobs` if the metric from
+     `.claude/plans/future-queued-workflows-metric.md` lands later.
+
+3. **Fleet size & lifecycle state.** `AWS/AutoScaling` namespace, dimension
+   `AutoScalingGroupName`:
+   - Primary widget: `GroupDesiredCapacity`, `GroupInServiceInstances`,
+     `GroupMinSize`, `GroupMaxSize` — desired vs. actual vs. bounds at a glance.
+   - Transients widget: `GroupPendingInstances`, `GroupTerminatingInstances`,
+     `GroupStandbyInstances`.
+   - Warm pool widget (conditional — only rendered when warm pool is enabled,
+     so no "no data" holes): `WarmPoolDesiredCapacity`, `WarmPoolWarmedCapacity`,
+     `WarmPoolPendingCapacity`, `WarmPoolTerminatingCapacity`.
+
+4. **Autoscaling — why it scaled.** Scaling policies at `autoscaling.tf:35,44`
+   are step-scaling triggered by alarms on `IdleRunners` thresholds.
+   - `IdleRunners` time series with horizontal annotation lines at
+     `var.autoscaling_idle_low` and `var.autoscaling_idle_high` — operator
+     sees "we scaled out because we hit the floor at 13:42".
+   - Alarm-state timeline for `IdleRunnersLow` and `IdleRunnersTooHigh` —
+     shows breach windows.
+   - ASG activity isn't a CloudWatch metric; use a markdown widget with a
+     deep link to the ASG activity console rather than fabricating a panel.
+
+5. **Host health (EC2, across the ASG).** `AWS/EC2` with
+   `AutoScalingGroupName` dimension:
+   - `CPUUtilization` average + p95.
+   - `StatusCheckFailed` summed.
+   - No `CWAgent` widgets in this PR — host metrics aren't available on
+     runners until infrahouse/puppet-code#270 lands. The follow-up PR that
+     adds disk/memory alarms also adds matching disk/memory widgets here.
+
+6. **Spot interruptions (conditional).** Only rendered when
+   `on_demand_percentage_above_base_capacity < 100`:
+   - `GroupSpotInstances` time series.
+   - Spot interruption events (EventBridge → CloudWatch metric, or link-out
+     if we don't already wire this; confirm in implementation pass).
+
+7. **Lambda lifecycle — the runner plumbing.** One compact row, three columns
+   (`record_metric`, `runner_registration`, `runner_deregistration`):
+   Invocations, Errors, Duration p95, Throttles from `AWS/Lambda`. Error
+   alarms are already wired by `terraform-aws-lambda-monitored`; this panel
+   is purely for at-a-glance health.
+
+Outputs:
+- `dashboard_name` and `dashboard_url` added to `outputs.tf` so callers can
+  link from their own runbooks.
+
+Implementation notes:
+- Conditional widgets (warm pool, disk/mem, spot) built by assembling the
+  widget list with `concat(...)` on known-at-plan conditions — no dynamic
+  count on the dashboard resource itself.
+- Resist the urge to parameterize thresholds, widths, or refresh intervals.
+  Hardcode sensible defaults; revisit only if a real use case appears.
+
+**B5. Documentation.**
+
+- `README.md` — update "What's New" / alarms section and the alarms contract:
+  which alarms fire, where they go, what's required vs optional
+  (`alarm_emails` required, `alarm_topic_arns` optional fan-out list,
+  dashboard always on).
+  Let terraform-docs regenerate the variables/outputs tables.
+- `docs/monitoring.md` — full alarms inventory (CPU, unhealthy hosts,
+  disk/memory if enabled, Lambda errors from each submodule), SNS topic
+  provisioning behavior, dashboard layout.
+- `docs/examples.md` — add "Fan out to PagerDuty/Slack via `alarm_topic_arns`"
+  snippet.
+- `CHANGELOG.md` — auto-generated by `git-cliff` on release. Must include
+  a `BREAKING CHANGES` entry for `sns_topic_alarm_arn` → `alarm_topic_arns`.
+
+## Migration considerations
+
+Callers currently in one of two states (state-3 from the old plan — only
+`sns_topic_alarm_arn` set — is impossible because `alarm_emails` is already
+required by validation):
+
+1. **Only `alarm_emails` set** — the broken case #93 reports.
+   After this PR: module creates its own SNS topic, subscribes emails, and
+   the CPU (plus new) alarms fire against it. Plan diff will show a new SNS
+   topic + subscriptions + the CPU alarm flipping from `count=0` to `count=1`
+   + new alarms + new dashboard. All additive. Documented as a fix.
+
+2. **Both `alarm_emails` and `sns_topic_alarm_arn` set** — **breaking**.
+   `sns_topic_alarm_arn` is removed. Callers must rename to
+   `alarm_topic_arns = [<old value>]`. Post-migration: the module creates
+   its own topic and subscribes emails there, AND continues to fan out to
+   the caller's topic via `alarm_topic_arns`. This is strictly more coverage
+   than before, but it's a plan diff callers must approve.
+
+No `moved` blocks required — the new SNS topic, subscriptions, and
+dashboard are genuinely new resources. The variable rename is a caller-side
+change, not state migration.
+
+Upgrade note for `CHANGELOG.md` and README "Upgrading to 3.6.0":
+```hcl
+# Before
+sns_topic_alarm_arn = "arn:aws:sns:...:shared-alarms"
+
+# After
+alarm_topic_arns = ["arn:aws:sns:...:shared-alarms"]
+```
+
+## Testing
+
+- `tests/test_module.py` — default selector path (`alarm_emails` only):
+  assert the module-owned SNS topic exists, emails are subscribed, and the
+  CPU + new alarms fire against it. Assert the dashboard resource exists.
+- Test fixture check: confirm `test_data/actions-runner/outputs.tf` exposes
+  any new root outputs (`dashboard_url`, `alarm_topic_arn`, etc.) so tests
+  can read them. (Per standing feedback on verifying test fixture wrappers.)
+- `make test-clean` before PR.
+
+## Out of scope
+
+- Rewriting `record_metric` / `runner_registration` / `runner_deregistration`
+  alarm plumbing — already handled by `terraform-aws-lambda-monitored`.
+- Full rewrite of `docs/monitoring.md` beyond the alarms contract section.
+- Implementing issue #79's remaining items (`examples/`, CODEOWNERS,
+  `.pre-commit-config.yaml`, PR/issue templates). Those go in a separate
+  "repo hygiene" PR — not coupled to the alarms fix.
+
+## Commit shape
+
+One PR, three conventional-commit commits so the changelog reads cleanly:
+
+1. `docs: fix mkdocs sidebar and add examples page` — `mkdocs.yml` nav +
+   `docs/examples.md` + this plan file.
+2. `feat!: adopt lambda-monitored SNS pattern; always create alarm topic (#93)` —
+   `alarms.tf`, `variables.tf` (drop `sns_topic_alarm_arn`; add
+   `alarm_topic_arns`), `cloudwatch.tf`
+   (remove `count` gate; use `local.all_alarm_topic_arns`), `outputs.tf`
+   updates, README + `docs/monitoring.md` + `docs/examples.md` updates.
+   The `!` marks the breaking rename for conventional-commits.
+3. `feat: add alarm coverage and CloudWatch dashboard (#93)` — additional
+   alarms from B3, `dashboard.tf`, dashboard outputs, docs.
+
+Version bump: `major` (`3.5.0` → `4.0.0`). Breaking rename of
+`sns_topic_alarm_arn` → `alarm_topic_arns` is caller-visible; semver
+discipline requires a major bump regardless of how mechanical the migration.
+Use `make release-major`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Self-hosted runners offer several advantages over GitHub-hosted runners:
 
 ## What's New
 
+- **v4.0.0 — Unified alarm notification channel (#93):**
+    - The module now **always** creates its own SNS topic for alarms and subscribes every address in `alarm_emails`. Previously, EC2 CPU alarms were silently disabled when callers set only `alarm_emails` and not the (optional, defaulted-null) `sns_topic_alarm_arn`, resulting in EC2 instances reported as unmonitored.
+    - **Breaking:** `sns_topic_alarm_arn` (singular, optional) is replaced by `alarm_topic_arns` (list, default `[]`). Callers upgrading who previously set `sns_topic_alarm_arn = "<arn>"` should rename to `alarm_topic_arns = ["<arn>"]`. After the rename, the module creates its own topic **and** fans out to the provided ARNs — strictly more coverage.
+    - Every alarm in the module (CPU and all future alarms) now fires to the module-owned topic plus any ARNs in `alarm_topic_arns`.
+    - New output `alarm_topic_arn` exposes the module-owned topic for additional subscriptions.
 - **Migrated runner_deregistration lambda to terraform-aws-lambda-monitored module (v1.0.4):**
     - Automated dependency packaging for Lambda functions (no more custom package.sh scripts)
     - Built-in error monitoring and alerting via SNS
@@ -55,6 +60,37 @@ Self-hosted runners offer several advantages over GitHub-hosted runners:
     - Orphaned runners are now automatically deregistered.
 
 ## Migration Guide
+
+### Upgrading to v4.0.0 (Unified Alarm Topic)
+
+The v4.0.0 release renames `sns_topic_alarm_arn` (singular, optional) to
+`alarm_topic_arns` (list, optional). The module also starts creating its own
+SNS topic unconditionally and subscribing `alarm_emails` to it.
+
+#### Who Needs To Change Anything
+
+Only callers who previously set `sns_topic_alarm_arn`. If you only set
+`alarm_emails`, no caller-side change is needed — the upgrade is purely
+additive (you stop being silently unmonitored).
+
+#### Rename
+
+```hcl
+# Before
+module "actions-runner" {
+  # ...
+  sns_topic_alarm_arn = "arn:aws:sns:us-east-1:123456789012:shared-alarms"
+}
+
+# After
+module "actions-runner" {
+  # ...
+  alarm_topic_arns = ["arn:aws:sns:us-east-1:123456789012:shared-alarms"]
+}
+```
+
+After the rename, alarms fire to **both** the module-owned topic (driven by
+`alarm_emails`) and every ARN in `alarm_topic_arns`.
 
 ### Upgrading to v3.1.0+ (runner_deregistration Migration)
 
@@ -182,6 +218,8 @@ module "actions-runner" {
 | [aws_key_pair.actions-runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_launch_template.actions-runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.actions-runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_sns_topic.alarms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_subscription.alarm_emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.icmp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
@@ -206,6 +244,7 @@ module "actions-runner" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_emails"></a> [alarm\_emails](#input\_alarm\_emails) | List of email addresses to receive alarm notifications for Lambda function errors. At least one email is required for Lambda error monitoring. | `list(string)` | n/a | yes |
+| <a name="input_alarm_topic_arns"></a> [alarm\_topic\_arns](#input\_alarm\_topic\_arns) | List of existing SNS topic ARNs to fan alarm notifications out to (e.g. PagerDuty, Slack, shared org topics). The module always creates its own topic for alarm\_emails; this list is additive. | `list(string)` | `[]` | no |
 | <a name="input_allowed_drain_time"></a> [allowed\_drain\_time](#input\_allowed\_drain\_time) | How many seconds to give a running job to finish after the instance fails health checks. Maximum allowed value is 900 seconds. | `number` | `900` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI id for EC2 instances. By default, latest Ubuntu var.ubuntu\_codename. | `string` | `null` | no |
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | The CPU architecture for the Lambda function; valid values are `x86_64` or `arm64`. | `string` | `"x86_64"` | no |
@@ -243,7 +282,6 @@ module "actions-runner" {
 | <a name="input_python_version"></a> [python\_version](#input\_python\_version) | Python version to run lambda on. Must be one of https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html | `string` | `"python3.12"` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name that will be created and used by EC2 instances | `string` | `"actions-runner"` | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Root volume size in EC2 instance in Gigabytes | `number` | `30` | no |
-| <a name="input_sns_topic_alarm_arn"></a> [sns\_topic\_alarm\_arn](#input\_sns\_topic\_alarm\_arn) | ARN of SNS topic for Cloudwatch alarms on base EC2 instance. | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet ids where the actions runner instances will be created. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to resources. | `map(string)` | `{}` | no |
 | <a name="input_ubuntu_codename"></a> [ubuntu\_codename](#input\_ubuntu\_codename) | Ubuntu version to use for the actions runner. | `string` | `"noble"` | no |
@@ -254,6 +292,7 @@ module "actions-runner" {
 
 | Name | Description |
 |------|-------------|
+| <a name="output_alarm_topic_arn"></a> [alarm\_topic\_arn](#output\_alarm\_topic\_arn) | ARN of the SNS topic this module creates for alarm notifications. alarm\_emails are subscribed to this topic; any ARNs passed in alarm\_topic\_arns receive the same alarms in addition to this one. |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | Autoscaling group name. |
 | <a name="output_deregistration_lambda_name"></a> [deregistration\_lambda\_name](#output\_deregistration\_lambda\_name) | Name of the runner\_deregistration lambda function. |
 | <a name="output_deregistration_log_group"></a> [deregistration\_log\_group](#output\_deregistration\_log\_group) | CloudWatch log group name for the deregistration lambda |

--- a/README.md
+++ b/README.md
@@ -211,9 +211,16 @@ module "actions-runner" {
 | [aws_autoscaling_lifecycle_hook.terminating](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_lifecycle_hook) | resource |
 | [aws_autoscaling_policy.scale_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_policy) | resource |
 | [aws_autoscaling_policy.scale_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_policy) | resource |
+| [aws_cloudwatch_dashboard.actions_runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
+| [aws_cloudwatch_metric_alarm.asg_at_max](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.asg_launch_stuck](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.asg_saturated_at_max](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.asg_zero_in_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.cpu_utilization_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.idle_runners_high](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.idle_runners_low](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.runner_registration_gap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.warm_pool_empty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_policy.required](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_key_pair.actions-runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_launch_template.actions-runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
@@ -294,6 +301,8 @@ module "actions-runner" {
 |------|-------------|
 | <a name="output_alarm_topic_arn"></a> [alarm\_topic\_arn](#output\_alarm\_topic\_arn) | ARN of the SNS topic this module creates for alarm notifications. alarm\_emails are subscribed to this topic; any ARNs passed in alarm\_topic\_arns receive the same alarms in addition to this one. |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | Autoscaling group name. |
+| <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard the module creates for this runner pool. |
+| <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL of the CloudWatch dashboard the module creates for this runner pool. |
 | <a name="output_deregistration_lambda_name"></a> [deregistration\_lambda\_name](#output\_deregistration\_lambda\_name) | Name of the runner\_deregistration lambda function. |
 | <a name="output_deregistration_log_group"></a> [deregistration\_log\_group](#output\_deregistration\_log\_group) | CloudWatch log group name for the deregistration lambda |
 | <a name="output_record_metric_lambda_name"></a> [record\_metric\_lambda\_name](#output\_record\_metric\_lambda\_name) | Name of the record\_metric lambda function. |

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,6 +1,7 @@
 resource "aws_sns_topic" "alarms" {
-  name = "${aws_autoscaling_group.actions-runner.name}-alarms"
-  tags = local.default_module_tags
+  name              = "${aws_autoscaling_group.actions-runner.name}-alarms"
+  kms_master_key_id = "alias/aws/sns"
+  tags              = local.default_module_tags
 }
 
 resource "aws_sns_topic_subscription" "alarm_emails" {

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,0 +1,11 @@
+resource "aws_sns_topic" "alarms" {
+  name = "${aws_autoscaling_group.actions-runner.name}-alarms"
+  tags = local.default_module_tags
+}
+
+resource "aws_sns_topic_subscription" "alarm_emails" {
+  for_each  = toset(var.alarm_emails)
+  topic_arn = aws_sns_topic.alarms.arn
+  protocol  = "email"
+  endpoint  = each.value
+}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,4 @@
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_alarm" {
-  count               = var.sns_topic_alarm_arn != null ? 1 : 0
   alarm_name          = format("CPU Alarm on ASG %s", aws_autoscaling_group.actions-runner.name)
   comparison_operator = "GreaterThanThreshold"
   metric_name         = "CPUUtilization"
@@ -8,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_alarm" {
   period              = 60
   threshold           = 90
   namespace           = "AWS/EC2"
-  alarm_actions       = [var.sns_topic_alarm_arn]
+  alarm_actions       = local.all_alarm_topic_arns
   alarm_description   = format("%s alarm - CPU exceeds 90 percent", aws_autoscaling_group.actions-runner.name)
   dimensions = {
     AutoScalingGroupName = aws_autoscaling_group.actions-runner.name

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -14,6 +14,236 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_alarm" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "asg_at_max" {
+  alarm_name          = "ASGAtMax-${aws_autoscaling_group.actions-runner.name}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "GroupInServiceInstances"
+  namespace           = "AWS/AutoScaling"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = local.asg_max
+  alarm_description   = "ASG ${aws_autoscaling_group.actions-runner.name} pinned at max size for 5 minutes — raise ceiling or investigate stuck jobs"
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+  }
+  alarm_actions      = local.all_alarm_topic_arns
+  treat_missing_data = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "asg_zero_in_service" {
+  alarm_name          = "ASGZeroInService-${aws_autoscaling_group.actions-runner.name}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  evaluation_periods  = 10
+  alarm_description   = "ASG ${aws_autoscaling_group.actions-runner.name} has 0 instances in service while desired capacity > 0 for 10 minutes"
+  alarm_actions       = local.all_alarm_topic_arns
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "e1"
+    expression  = "IF(m_is < 1 AND m_dc > 0, 1, 0)"
+    label       = "In-service dropped to zero with desired > 0"
+    return_data = true
+  }
+
+  metric_query {
+    id = "m_is"
+    metric {
+      metric_name = "GroupInServiceInstances"
+      namespace   = "AWS/AutoScaling"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+
+  metric_query {
+    id = "m_dc"
+    metric {
+      metric_name = "GroupDesiredCapacity"
+      namespace   = "AWS/AutoScaling"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "warm_pool_empty" {
+  count = var.on_demand_base_capacity == null ? 1 : 0
+
+  alarm_name          = "WarmPoolEmpty-${aws_autoscaling_group.actions-runner.name}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  evaluation_periods  = 10
+  alarm_description   = "Warm pool for ${aws_autoscaling_group.actions-runner.name} is empty (warmed = 0 while desired > 0) — the latency-hiding optimization is off"
+  alarm_actions       = local.all_alarm_topic_arns
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "e1"
+    expression  = "IF(m_warmed < 1 AND m_desired > 0, 1, 0)"
+    label       = "Warm pool drained"
+    return_data = true
+  }
+
+  metric_query {
+    id = "m_warmed"
+    metric {
+      metric_name = "WarmPoolWarmedCapacity"
+      namespace   = "AWS/AutoScaling"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+
+  metric_query {
+    id = "m_desired"
+    metric {
+      metric_name = "WarmPoolDesiredCapacity"
+      namespace   = "AWS/AutoScaling"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+}
+
+# Puppet provisioning can legitimately run up to ~15 min on cold boot; the
+# 20-minute sustained threshold sits above that ceiling so normal scale-out
+# doesn't trip it.
+resource "aws_cloudwatch_metric_alarm" "asg_launch_stuck" {
+  alarm_name          = "ASGLaunchStuck-${aws_autoscaling_group.actions-runner.name}"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "GroupPendingInstances"
+  namespace           = "AWS/AutoScaling"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 20
+  threshold           = 0
+  alarm_description   = "ASG ${aws_autoscaling_group.actions-runner.name} has pending instances stuck for >20 minutes — likely launch failure (bad launch template, capacity, IAM)"
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+  }
+  alarm_actions      = local.all_alarm_topic_arns
+  treat_missing_data = "notBreaching"
+}
+
+# Instances only reach InService after the Launch lifecycle hook completes
+# (runner_registration Lambda), so a registered runner should exist by then.
+# A sustained gap catches the "EC2 up but never registered" class.
+resource "aws_cloudwatch_metric_alarm" "runner_registration_gap" {
+  alarm_name          = "RunnerRegistrationGap-${aws_autoscaling_group.actions-runner.name}"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 0
+  evaluation_periods  = 5
+  alarm_description   = "Registered runners fewer than InService EC2 instances for >5 minutes on ASG ${aws_autoscaling_group.actions-runner.name} — instances launched but never registered with GitHub"
+  alarm_actions       = local.all_alarm_topic_arns
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "e1"
+    expression  = "m_is - (m_busy + m_idle)"
+    label       = "InService - (Busy + Idle)"
+    return_data = true
+  }
+
+  metric_query {
+    id = "m_is"
+    metric {
+      metric_name = "GroupInServiceInstances"
+      namespace   = "AWS/AutoScaling"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+
+  metric_query {
+    id = "m_busy"
+    metric {
+      metric_name = "BusyRunners"
+      namespace   = "GitHubRunners"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        asg_name = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+
+  metric_query {
+    id = "m_idle"
+    metric {
+      metric_name = "IdleRunners"
+      namespace   = "GitHubRunners"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        asg_name = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+}
+
+# Distinct from IdleRunnersTooLow (which triggers scale-out): here we're
+# already at max size with zero idle runners, so scale-out can't help and
+# jobs are queueing.
+resource "aws_cloudwatch_metric_alarm" "asg_saturated_at_max" {
+  alarm_name          = "ASGSaturatedAtMax-${aws_autoscaling_group.actions-runner.name}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  evaluation_periods  = 10
+  alarm_description   = "ASG ${aws_autoscaling_group.actions-runner.name} at max size with all runners busy for 10 minutes — scale-out cannot help; jobs queueing"
+  alarm_actions       = local.all_alarm_topic_arns
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "e1"
+    expression  = "IF(m_is >= ${local.asg_max} AND m_busy >= m_is, 1, 0)"
+    label       = "At max size and fully utilized"
+    return_data = true
+  }
+
+  metric_query {
+    id = "m_is"
+    metric {
+      metric_name = "GroupInServiceInstances"
+      namespace   = "AWS/AutoScaling"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        AutoScalingGroupName = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+
+  metric_query {
+    id = "m_busy"
+    metric {
+      metric_name = "BusyRunners"
+      namespace   = "GitHubRunners"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        asg_name = aws_autoscaling_group.actions-runner.name
+      }
+    }
+  }
+}
+
 module "record_metric" {
   source                         = "./modules/record_metric"
   asg_name                       = aws_autoscaling_group.actions-runner.name

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_alarm" {
   comparison_operator = "GreaterThanThreshold"
   metric_name         = "CPUUtilization"
   statistic           = "Average"
-  evaluation_periods  = 1
+  evaluation_periods  = 5
   period              = 60
   threshold           = 90
   namespace           = "AWS/EC2"
@@ -14,7 +14,11 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_alarm" {
   }
 }
 
+# Skipped on fixed-size pools (asg_min == asg_max) where sitting at max is
+# the intended steady state and would alarm continuously.
 resource "aws_cloudwatch_metric_alarm" "asg_at_max" {
+  count = local.asg_min < local.asg_max ? 1 : 0
+
   alarm_name          = "ASGAtMax-${aws_autoscaling_group.actions-runner.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   metric_name         = "GroupInServiceInstances"
@@ -142,12 +146,19 @@ resource "aws_cloudwatch_metric_alarm" "asg_launch_stuck" {
 # Instances only reach InService after the Launch lifecycle hook completes
 # (runner_registration Lambda), so a registered runner should exist by then.
 # A sustained gap catches the "EC2 up but never registered" class.
+#
+# Threshold > 1 (not > 0) absorbs brief single-instance transients — most
+# commonly an instance waking from warm-pool hibernation: for ~30–60s the
+# instance is InService but the runner agent hasn't re-announced online to
+# GitHub yet, so m_is=1 and m_busy+m_idle=0. The 5-period sustained window
+# already covers this, but > 1 adds a belt to the suspenders. The real
+# #93 failure mode is a permanent gap, which trips any positive threshold.
 resource "aws_cloudwatch_metric_alarm" "runner_registration_gap" {
   alarm_name          = "RunnerRegistrationGap-${aws_autoscaling_group.actions-runner.name}"
   comparison_operator = "GreaterThanThreshold"
-  threshold           = 0
+  threshold           = 1
   evaluation_periods  = 5
-  alarm_description   = "Registered runners fewer than InService EC2 instances for >5 minutes on ASG ${aws_autoscaling_group.actions-runner.name} — instances launched but never registered with GitHub"
+  alarm_description   = "Registered runners more than 1 fewer than InService EC2 instances for >5 minutes on ASG ${aws_autoscaling_group.actions-runner.name} — instances launched but never registered with GitHub"
   alarm_actions       = local.all_alarm_topic_arns
   treat_missing_data  = "notBreaching"
 
@@ -200,8 +211,11 @@ resource "aws_cloudwatch_metric_alarm" "runner_registration_gap" {
 
 # Distinct from IdleRunnersTooLow (which triggers scale-out): here we're
 # already at max size with zero idle runners, so scale-out can't help and
-# jobs are queueing.
+# jobs are queueing. Skipped on fixed-size pools where scaling isn't
+# available — saturation is the intended steady state.
 resource "aws_cloudwatch_metric_alarm" "asg_saturated_at_max" {
+  count = local.asg_min < local.asg_max ? 1 : 0
+
   alarm_name          = "ASGSaturatedAtMax-${aws_autoscaling_group.actions-runner.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = 1

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -5,14 +5,14 @@ locals {
   dashboard_alarm_arns = concat(
     [
       aws_cloudwatch_metric_alarm.cpu_utilization_alarm.arn,
-      aws_cloudwatch_metric_alarm.asg_at_max.arn,
       aws_cloudwatch_metric_alarm.asg_zero_in_service.arn,
       aws_cloudwatch_metric_alarm.asg_launch_stuck.arn,
       aws_cloudwatch_metric_alarm.runner_registration_gap.arn,
-      aws_cloudwatch_metric_alarm.asg_saturated_at_max.arn,
       aws_cloudwatch_metric_alarm.idle_runners_low.arn,
       aws_cloudwatch_metric_alarm.idle_runners_high.arn,
     ],
+    aws_cloudwatch_metric_alarm.asg_at_max[*].arn,
+    aws_cloudwatch_metric_alarm.asg_saturated_at_max[*].arn,
     aws_cloudwatch_metric_alarm.warm_pool_empty[*].arn,
   )
 

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -1,0 +1,340 @@
+locals {
+  dashboard_region  = data.aws_region.current.name
+  warm_pool_enabled = var.on_demand_base_capacity == null
+
+  dashboard_alarm_arns = concat(
+    [
+      aws_cloudwatch_metric_alarm.cpu_utilization_alarm.arn,
+      aws_cloudwatch_metric_alarm.asg_at_max.arn,
+      aws_cloudwatch_metric_alarm.asg_zero_in_service.arn,
+      aws_cloudwatch_metric_alarm.asg_launch_stuck.arn,
+      aws_cloudwatch_metric_alarm.runner_registration_gap.arn,
+      aws_cloudwatch_metric_alarm.asg_saturated_at_max.arn,
+      aws_cloudwatch_metric_alarm.idle_runners_low.arn,
+      aws_cloudwatch_metric_alarm.idle_runners_high.arn,
+    ],
+    aws_cloudwatch_metric_alarm.warm_pool_empty[*].arn,
+  )
+
+  dashboard_identity_line = join(" · ", compact([
+    "**env:** ${var.environment}",
+    length(var.extra_labels) > 0 ? "**labels:** ${join(", ", var.extra_labels)}" : "",
+    "**region:** ${local.dashboard_region}",
+  ]))
+
+  dashboard_widgets = concat(
+    # -----------------------------------------------------------------------
+    # Identity + Alarms
+    # -----------------------------------------------------------------------
+    [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 2
+        properties = {
+          markdown = "# ${local.asg_name}\n${local.dashboard_identity_line}"
+        }
+      },
+      {
+        type   = "text"
+        x      = 0
+        y      = 2
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "## Alarms"
+        }
+      },
+      {
+        type   = "alarm"
+        x      = 0
+        y      = 3
+        width  = 24
+        height = 4
+        properties = {
+          title  = "Alarm state"
+          alarms = local.dashboard_alarm_arns
+        }
+      },
+
+      # -----------------------------------------------------------------------
+      # GitHub
+      # -----------------------------------------------------------------------
+      {
+        type   = "text"
+        x      = 0
+        y      = 7
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "## GitHub"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 8
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Runners (Idle / Busy) with scale thresholds"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["GitHubRunners", "IdleRunners", "asg_name", local.asg_name, { label = "Idle", stat = "Average" }],
+            [".", "BusyRunners", ".", ".", { label = "Busy", stat = "Average" }],
+          ]
+          annotations = {
+            horizontal = [
+              { value = var.idle_runners_target_count, label = "Idle scale target (low / high)", color = "#d62728" },
+            ]
+          }
+          yAxis = {
+            left = { min = 0 }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 8
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Utilization %"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            [
+              {
+                expression = "IF((busy + idle) > 0, 100 * busy / (busy + idle), 0)"
+                label      = "Utilization %"
+                id         = "util"
+              }
+            ],
+            ["GitHubRunners", "BusyRunners", "asg_name", local.asg_name, { id = "busy", visible = false, stat = "Average" }],
+            [".", "IdleRunners", ".", ".", { id = "idle", visible = false, stat = "Average" }],
+          ]
+          yAxis = {
+            left = { min = 0, max = 100 }
+          }
+        }
+      },
+
+      # -----------------------------------------------------------------------
+      # ASG
+      # -----------------------------------------------------------------------
+      {
+        type   = "text"
+        x      = 0
+        y      = 14
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "## ASG"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 15
+        width  = 24
+        height = 6
+        properties = {
+          title  = "Fleet size (capacity, left) and transients (count, right)"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/AutoScaling", "GroupDesiredCapacity", "AutoScalingGroupName", local.asg_name, { label = "Desired", stat = "Average" }],
+            [".", "GroupInServiceInstances", ".", ".", { label = "In service", stat = "Average" }],
+            [".", "GroupMinSize", ".", ".", { label = "Min", stat = "Average" }],
+            [".", "GroupMaxSize", ".", ".", { label = "Max", stat = "Average" }],
+            [".", "GroupPendingInstances", ".", ".", { label = "Pending (r)", stat = "Average", yAxis = "right" }],
+            [".", "GroupTerminatingInstances", ".", ".", { label = "Terminating (r)", stat = "Average", yAxis = "right" }],
+            [".", "GroupStandbyInstances", ".", ".", { label = "Standby (r)", stat = "Average", yAxis = "right" }],
+          ]
+          yAxis = {
+            left  = { min = 0, label = "Capacity" }
+            right = { min = 0, label = "Transient count" }
+          }
+        }
+      },
+    ],
+    local.warm_pool_enabled ? [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 21
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Warm pool"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/AutoScaling", "WarmPoolDesiredCapacity", "AutoScalingGroupName", local.asg_name, { label = "Desired", stat = "Average" }],
+            [".", "WarmPoolWarmedCapacity", ".", ".", { label = "Warmed", stat = "Average" }],
+            [".", "WarmPoolPendingCapacity", ".", ".", { label = "Pending", stat = "Average" }],
+            [".", "WarmPoolTerminatingCapacity", ".", ".", { label = "Terminating", stat = "Average" }],
+          ]
+          yAxis = {
+            left = { min = 0 }
+          }
+        }
+      },
+    ] : [],
+    [
+      {
+        type   = "metric"
+        x      = local.warm_pool_enabled ? 12 : 0
+        y      = 21
+        width  = local.warm_pool_enabled ? 12 : 24
+        height = 6
+        properties = {
+          title  = "EC2 status check failures"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/EC2", "StatusCheckFailed", "AutoScalingGroupName", local.asg_name, { label = "StatusCheckFailed (sum)", stat = "Sum" }],
+          ]
+          yAxis = {
+            left = { min = 0 }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 27
+        width  = 24
+        height = 6
+        properties = {
+          title  = "EC2 CPU (fleet)"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/EC2", "CPUUtilization", "AutoScalingGroupName", local.asg_name, { label = "Average", stat = "Average" }],
+            ["AWS/EC2", "CPUUtilization", "AutoScalingGroupName", local.asg_name, { label = "p95", stat = "p95" }],
+          ]
+          yAxis = {
+            left = { min = 0, max = 100, label = "CPU %" }
+          }
+        }
+      },
+
+      # -----------------------------------------------------------------------
+      # Lambda
+      # -----------------------------------------------------------------------
+      {
+        type   = "text"
+        x      = 0
+        y      = 33
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "## Lambda"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 34
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Invocations"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/Lambda", "Invocations", "FunctionName", module.registration.lambda_name, { label = "registration", stat = "Sum" }],
+            [".", ".", ".", module.deregistration.lambda_name, { label = "deregistration", stat = "Sum" }],
+            [".", ".", ".", module.record_metric.lambda_name, { label = "record_metric", stat = "Sum" }],
+          ]
+          yAxis = {
+            left = { min = 0 }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 34
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Errors"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/Lambda", "Errors", "FunctionName", module.registration.lambda_name, { label = "registration", stat = "Sum" }],
+            [".", ".", ".", module.deregistration.lambda_name, { label = "deregistration", stat = "Sum" }],
+            [".", ".", ".", module.record_metric.lambda_name, { label = "record_metric", stat = "Sum" }],
+          ]
+          yAxis = {
+            left = { min = 0 }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 34
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Throttles"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/Lambda", "Throttles", "FunctionName", module.registration.lambda_name, { label = "registration", stat = "Sum" }],
+            [".", ".", ".", module.deregistration.lambda_name, { label = "deregistration", stat = "Sum" }],
+            [".", ".", ".", module.record_metric.lambda_name, { label = "record_metric", stat = "Sum" }],
+          ]
+          yAxis = {
+            left = { min = 0 }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 40
+        width  = 24
+        height = 6
+        properties = {
+          title  = "p95 duration"
+          view   = "timeSeries"
+          region = local.dashboard_region
+          period = 60
+          metrics = [
+            ["AWS/Lambda", "Duration", "FunctionName", module.registration.lambda_name, { label = "registration p95", stat = "p95" }],
+            [".", ".", ".", module.deregistration.lambda_name, { label = "deregistration p95", stat = "p95" }],
+            [".", ".", ".", module.record_metric.lambda_name, { label = "record_metric p95", stat = "p95" }],
+          ]
+          yAxis = {
+            left = { min = 0, label = "ms" }
+          }
+        }
+      },
+    ],
+  )
+}
+
+resource "aws_cloudwatch_dashboard" "actions_runner" {
+  dashboard_name = aws_autoscaling_group.actions-runner.name
+
+  dashboard_body = jsonencode({
+    widgets = local.dashboard_widgets
+  })
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,7 +142,7 @@ extra_repos = {
 |----------|------|---------|-------------|
 | `alarm_emails` | list(string) | required | Email addresses for alerts |
 | `error_rate_threshold` | number | `10` | Error rate % threshold |
-| `sns_topic_alarm_arn` | string | `null` | Existing SNS topic for EC2 alarms |
+| `alarm_topic_arns` | list(string) | `[]` | Additional SNS topic ARNs to fan alarms out to (PagerDuty, Slack, shared org topics). The module always creates its own topic for `alarm_emails`; this list is additive. |
 
 ## Tags
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,148 @@
+# Examples
+
+Common deployment patterns for the `terraform-aws-actions-runner` module.
+
+## Minimal: GitHub Token Auth
+
+The smallest viable configuration — a single runner authenticated with a classic GitHub token.
+
+```hcl
+module "actions_runner" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 3.5"
+
+  environment             = "production"
+  github_org_name         = "your-org"
+  subnet_ids              = ["subnet-abc123", "subnet-def456"]
+  alarm_emails            = ["oncall@example.com"]
+  github_token_secret_arn = aws_secretsmanager_secret.github_token.arn
+}
+```
+
+## GitHub App Authentication
+
+Preferred over classic tokens — App credentials scope cleanly to the org and rotate automatically.
+
+```hcl
+module "actions_runner" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 3.5"
+
+  environment              = "production"
+  github_org_name          = "your-org"
+  subnet_ids               = module.service_network.subnet_private_ids
+  alarm_emails             = ["oncall@example.com"]
+
+  github_app_pem_secret_arn = aws_secretsmanager_secret.github_app_pem.arn
+  github_app_id             = 123456
+}
+```
+
+See [Authentication](authentication.md) for how to provision the GitHub App and PEM secret.
+
+## Spot Instances with an On-Demand Floor
+
+Use spot for the elastic tail, keep a small on-demand baseline so at least one runner is always available for critical jobs.
+
+```hcl
+module "actions_runner" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 3.5"
+
+  environment             = "production"
+  github_org_name         = "your-org"
+  subnet_ids              = module.service_network.subnet_private_ids
+  alarm_emails            = ["oncall@example.com"]
+  github_token_secret_arn = aws_secretsmanager_secret.github_token.arn
+
+  asg_min_size            = 2
+  asg_max_size            = 20
+  on_demand_base_capacity = 1
+  instance_type           = "t3a.large"
+}
+```
+
+## Warm Pool for Fast Job Starts
+
+The warm pool keeps hibernated instances ready so newly scheduled jobs don't wait for full EC2 boot. See [Scaling](scaling.md) for how warm pool interacts with autoscaling.
+
+```hcl
+module "actions_runner" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 3.5"
+
+  environment             = "production"
+  github_org_name         = "your-org"
+  subnet_ids              = module.service_network.subnet_private_ids
+  alarm_emails            = ["oncall@example.com"]
+  github_token_secret_arn = aws_secretsmanager_secret.github_token.arn
+
+  asg_min_size           = 2
+  asg_max_size           = 10
+  warm_pool_min_size     = 2
+  warm_pool_max_size     = 5
+}
+```
+
+## Custom Labels and Larger Instances
+
+Add labels so specific workflows can target this runner pool with `runs-on: [self-hosted, docker, terraform]`.
+
+```hcl
+module "actions_runner_heavy" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 3.5"
+
+  environment             = "production"
+  github_org_name         = "your-org"
+  subnet_ids              = module.service_network.subnet_private_ids
+  alarm_emails            = ["oncall@example.com"]
+  github_token_secret_arn = aws_secretsmanager_secret.github_token.arn
+
+  instance_type = "c6a.4xlarge"
+  extra_labels  = ["docker", "terraform", "heavy"]
+  asg_min_size  = 0
+  asg_max_size  = 8
+}
+```
+
+## Multiple Pools in One Account
+
+Deploy separate pools for different workload classes by invoking the module multiple times with distinct labels.
+
+```hcl
+module "runners_linux_small" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 3.5"
+
+  environment             = "production"
+  github_org_name         = "your-org"
+  subnet_ids              = module.service_network.subnet_private_ids
+  alarm_emails            = ["oncall@example.com"]
+  github_token_secret_arn = aws_secretsmanager_secret.github_token.arn
+
+  instance_type = "t3a.medium"
+  extra_labels  = ["small"]
+}
+
+module "runners_linux_large" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 3.5"
+
+  environment             = "production"
+  github_org_name         = "your-org"
+  subnet_ids              = module.service_network.subnet_private_ids
+  alarm_emails            = ["oncall@example.com"]
+  github_token_secret_arn = aws_secretsmanager_secret.github_token.arn
+
+  instance_type = "c6a.2xlarge"
+  extra_labels  = ["large"]
+}
+```
+
+## See Also
+
+- [Getting Started](getting-started.md)
+- [Configuration](configuration.md) — full variable reference
+- [Scaling](scaling.md) — warm pool and autoscaling tuning
+- [Troubleshooting](troubleshooting.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,7 +9,7 @@ The smallest viable configuration — a single runner authenticated with a class
 ```hcl
 module "actions_runner" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 3.5"
+  version = "3.5.0"
 
   environment             = "production"
   github_org_name         = "your-org"
@@ -26,7 +26,7 @@ Preferred over classic tokens — App credentials scope cleanly to the org and r
 ```hcl
 module "actions_runner" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 3.5"
+  version = "3.5.0"
 
   environment              = "production"
   github_org_name          = "your-org"
@@ -47,7 +47,7 @@ Use spot for the elastic tail, keep a small on-demand baseline so at least one r
 ```hcl
 module "actions_runner" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 3.5"
+  version = "3.5.0"
 
   environment             = "production"
   github_org_name         = "your-org"
@@ -69,7 +69,7 @@ The warm pool keeps hibernated instances ready so newly scheduled jobs don't wai
 ```hcl
 module "actions_runner" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 3.5"
+  version = "3.5.0"
 
   environment             = "production"
   github_org_name         = "your-org"
@@ -91,7 +91,7 @@ Add labels so specific workflows can target this runner pool with `runs-on: [sel
 ```hcl
 module "actions_runner_heavy" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 3.5"
+  version = "3.5.0"
 
   environment             = "production"
   github_org_name         = "your-org"
@@ -113,7 +113,7 @@ Deploy separate pools for different workload classes by invoking the module mult
 ```hcl
 module "runners_linux_small" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 3.5"
+  version = "3.5.0"
 
   environment             = "production"
   github_org_name         = "your-org"
@@ -127,7 +127,7 @@ module "runners_linux_small" {
 
 module "runners_linux_large" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 3.5"
+  version = "3.5.0"
 
   environment             = "production"
   github_org_name         = "your-org"
@@ -147,7 +147,7 @@ module "runners_linux_large" {
 ```hcl
 module "actions_runner" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "~> 4.0"
+  version = "3.5.0"
 
   environment             = "production"
   github_org_name         = "your-org"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -140,9 +140,32 @@ module "runners_linux_large" {
 }
 ```
 
+## Fan Out Alarms to PagerDuty / Slack
+
+`alarm_emails` is required and drives the module-owned SNS topic. To route the same alarms to additional destinations, pass existing SNS topic ARNs via `alarm_topic_arns` — every alarm fires to both channels.
+
+```hcl
+module "actions_runner" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "~> 4.0"
+
+  environment             = "production"
+  github_org_name         = "your-org"
+  subnet_ids              = module.service_network.subnet_private_ids
+  github_token_secret_arn = aws_secretsmanager_secret.github_token.arn
+
+  alarm_emails = ["oncall@example.com"]
+  alarm_topic_arns = [
+    aws_sns_topic.pagerduty_bridge.arn,
+    aws_sns_topic.shared_org_alerts.arn,
+  ]
+}
+```
+
 ## See Also
 
 - [Getting Started](getting-started.md)
 - [Configuration](configuration.md) — full variable reference
 - [Scaling](scaling.md) — warm pool and autoscaling tuning
+- [Monitoring](monitoring.md) — alarm contract and SNS fan-out
 - [Troubleshooting](troubleshooting.md)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -42,11 +42,13 @@ module "actions-runner" {
 
 ### Custom Metrics
 
-The `record_metric` Lambda publishes:
+The `record_metric` Lambda publishes, under the `GitHubRunners` namespace
+with an `asg_name` dimension:
 
-| Metric | Namespace | Description |
-|--------|-----------|-------------|
-| `IdleRunnersCount` | `InfraHouse/ActionsRunner` | Number of idle runners |
+| Metric | Description |
+|--------|-------------|
+| `BusyRunners` | Number of runners currently executing a job |
+| `IdleRunners` | Number of registered runners waiting for work |
 
 ### AWS Metrics
 
@@ -66,7 +68,7 @@ Created automatically:
 |-------|-----------|--------|
 | `idle_runners_low` | Idle < target | Scale out |
 | `idle_runners_high` | Idle > target | Scale in |
-| `cpu_utilization` | CPU > threshold | Alert (optional) |
+| `cpu_utilization` | CPU > 90% | Alert |
 
 ### Lambda Alarms
 
@@ -134,6 +136,11 @@ The module's monitoring setup satisfies Vanta's AWS Lambda checks:
 
 ## SNS Integration
 
+The module always creates its own SNS topic for alarm notifications and
+subscribes every address in `alarm_emails` to it. This is the required,
+load-bearing notification path — every operator gets at least one working
+alert channel.
+
 ### Email Alerts
 
 ```hcl
@@ -145,23 +152,45 @@ module "actions-runner" {
 }
 ```
 
-### Custom SNS Topics
+!!! warning "Email Confirmation Required"
+    AWS sends each subscriber a confirmation email. Recipients **must click
+    the confirmation link** before they will receive alerts.
 
-For integration with PagerDuty, Slack, or other systems, the module outputs the SNS topic ARN:
+### Fan Out to PagerDuty / Slack / Shared Topics
+
+For additional routing, pass one or more existing SNS topic ARNs via
+`alarm_topic_arns`. Every alarm this module creates will send to the
+module-owned topic **and** to each ARN in the list:
 
 ```hcl
-# After deployment, get the topic ARN
-output "alarm_topic_arn" {
-  value = module.actions-runner.alarm_topic_arn
-}
-
-# Subscribe your custom endpoint
-resource "aws_sns_topic_subscription" "pagerduty" {
-  topic_arn = module.actions-runner.alarm_topic_arn
-  protocol  = "https"
-  endpoint  = "https://events.pagerduty.com/integration/xxx/enqueue"
+module "actions-runner" {
+  alarm_emails     = ["oncall@example.com"]
+  alarm_topic_arns = [
+    aws_sns_topic.pagerduty_bridge.arn,
+    aws_sns_topic.shared_org_alerts.arn,
+  ]
 }
 ```
+
+### Subscribing Additional Endpoints to the Module-Owned Topic
+
+The module's topic ARN is exposed as an output:
+
+```hcl
+resource "aws_sns_topic_subscription" "slack" {
+  topic_arn = module.actions-runner.alarm_topic_arn
+  protocol  = "https"
+  endpoint  = "https://hooks.slack.com/services/..."
+}
+```
+
+### Host-Level Alarms (Disk, Memory)
+
+Not shipped yet. The runner AMI does not run the CloudWatch agent today, so
+disk and memory metrics are not available. Tracked in
+[infrahouse/puppet-code#270](https://github.com/infrahouse/puppet-code/issues/270);
+once the agent is wired into `role::github_runner`, a follow-up release of
+this module will add disk and memory alarms unconditionally.
 
 ## Debugging
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -68,7 +68,20 @@ Created automatically:
 |-------|-----------|--------|
 | `idle_runners_low` | Idle < target | Scale out |
 | `idle_runners_high` | Idle > target | Scale in |
-| `cpu_utilization` | CPU > 90% | Alert |
+
+### EC2 and ASG Alarms
+
+Created automatically, all routed to the module-owned SNS topic (and to any ARNs in `alarm_topic_arns`):
+
+| Alarm | Condition | Why |
+|-------|-----------|-----|
+| `CPU Alarm on ASG <name>` | Average CPU > 90% for 1 minute | Runner under sustained load |
+| `ASGAtMax-<name>` | `GroupInServiceInstances >= asg_max_size` for 5 minutes | Saturation — ceiling may need raising |
+| `ASGZeroInService-<name>` | `GroupInServiceInstances == 0` while `GroupDesiredCapacity > 0` for 10 minutes | Catastrophic — ASG wants instances but has none |
+| `WarmPoolEmpty-<name>` | `WarmPoolWarmedCapacity == 0` while `WarmPoolDesiredCapacity > 0` for 10 minutes (when warm pool enabled) | Latency-hiding optimization is off |
+| `ASGLaunchStuck-<name>` | `GroupPendingInstances > 0` sustained >20 minutes | Likely launch failure (LT, capacity, IAM). 20-min threshold sits above Puppet's ~15-min provisioning window. |
+| `RunnerRegistrationGap-<name>` | `GroupInServiceInstances - (BusyRunners + IdleRunners) > 0` for >5 minutes | EC2 is InService but runner never registered with GitHub |
+| `ASGSaturatedAtMax-<name>` | At max size with every runner busy for 10 minutes | Scale-out cannot help; jobs are queueing |
 
 ### Lambda Alarms
 
@@ -184,6 +197,25 @@ resource "aws_sns_topic_subscription" "slack" {
 }
 ```
 
+## CloudWatch Dashboard
+
+The module creates a CloudWatch dashboard named after the ASG. It surfaces, in order:
+
+1. Alarm state for every alarm this module owns.
+2. `BusyRunners` / `IdleRunners` and derived utilization.
+3. Fleet size (desired / in-service / min / max) and transient states (pending, terminating, standby).
+4. Warm pool capacity (when warm pool is enabled).
+5. `IdleRunners` with scale-out/scale-in thresholds annotated, plus autoscaling alarm state.
+6. EC2 CPU (average + p95) and status-check failures.
+7. Lambda lifecycle — invocations / errors / throttles / p95 duration for registration, deregistration, and record_metric.
+
+```hcl
+# URL available as an output
+output "runner_dashboard" {
+  value = module.actions-runner.dashboard_url
+}
+```
+
 ### Host-Level Alarms (Disk, Memory)
 
 Not shipped yet. The runner AMI does not run the CloudWatch agent today, so
@@ -231,12 +263,10 @@ aws autoscaling describe-warm-pool \
 
 The module provides these monitoring-related outputs:
 
-```hcl
-output "autoscaling_group_name" {
-  description = "ASG name for CloudWatch queries"
-}
-
-output "deregistration_log_group" {
-  description = "CloudWatch log group for deregistration Lambda"
-}
-```
+| Output | Description |
+|--------|-------------|
+| `autoscaling_group_name` | ASG name for CloudWatch queries |
+| `alarm_topic_arn` | Module-owned SNS topic ARN; subscribe additional endpoints here |
+| `dashboard_name` | Name of the CloudWatch dashboard |
+| `dashboard_url` | Deep link to the CloudWatch dashboard |
+| `deregistration_log_group` | CloudWatch log group for deregistration Lambda |

--- a/locals.tf
+++ b/locals.tf
@@ -34,4 +34,9 @@ locals {
   registration_hookname            = "registration"
   deregistration_hookname          = "deregistration"
   bootstrap_hookname               = "bootstrap"
+
+  all_alarm_topic_arns = concat(
+    [aws_sns_topic.alarms.arn],
+    var.alarm_topic_arns,
+  )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -22,6 +22,7 @@ locals {
   instance_memory_gb = ceil(data.aws_ec2_instance_type.this.memory_size / 1024.0)
   # Extra space on root volume for OS, packages, and swap beyond what hibernation needs for RAM
   hibernation_volume_overhead_gb = 10
+  asg_min                        = var.asg_min_size != null ? var.asg_min_size : length(var.subnet_ids)
   asg_max                        = var.asg_max_size != null ? var.asg_max_size : length(var.subnet_ids) + 1
   warm_pool_max                  = var.warm_pool_max_size != null ? var.warm_pool_max_size : local.asg_max
   # +1 ensures at least one pre-warmed instance is always available during scale-out

--- a/main.tf
+++ b/main.tf
@@ -143,6 +143,28 @@ resource "aws_autoscaling_group" "actions-runner" {
   max_instance_lifetime     = var.max_instance_lifetime_days * 24 * 3600
   health_check_grace_period = 0
   wait_for_capacity_timeout = "15m"
+
+  # Group metrics are not emitted to CloudWatch by default; enabling here
+  # makes the alarms in cloudwatch.tf and the dashboard widgets actually
+  # receive data. 1-minute granularity is free.
+  metrics_granularity = "1Minute"
+  enabled_metrics = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+    "WarmPoolDesiredCapacity",
+    "WarmPoolWarmedCapacity",
+    "WarmPoolPendingCapacity",
+    "WarmPoolTerminatingCapacity",
+    "WarmPoolTotalCapacity",
+    "GroupAndWarmPoolDesiredCapacity",
+    "GroupAndWarmPoolTotalCapacity",
+  ]
   dynamic "launch_template" {
     for_each = var.on_demand_base_capacity == null ? [1] : []
     content {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,15 @@ theme:
 
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - Configuration: configuration.md
+  - Authentication: authentication.md
+  - Scaling: scaling.md
+  - Monitoring: monitoring.md
+  - Examples: examples.md
+  - Troubleshooting: troubleshooting.md
+  - Comparison: comparison.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,13 @@ output "alarm_topic_arn" {
   description = "ARN of the SNS topic this module creates for alarm notifications. alarm_emails are subscribed to this topic; any ARNs passed in alarm_topic_arns receive the same alarms in addition to this one."
   value       = aws_sns_topic.alarms.arn
 }
+
+output "dashboard_name" {
+  description = "Name of the CloudWatch dashboard the module creates for this runner pool."
+  value       = aws_cloudwatch_dashboard.actions_runner.dashboard_name
+}
+
+output "dashboard_url" {
+  description = "URL of the CloudWatch dashboard the module creates for this runner pool."
+  value       = "https://${data.aws_region.current.name}.console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.current.name}#dashboards:name=${aws_cloudwatch_dashboard.actions_runner.dashboard_name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "record_metric_lambda_name" {
   description = "Name of the record_metric lambda function."
   value       = module.record_metric.lambda_name
 }
+
+output "alarm_topic_arn" {
+  description = "ARN of the SNS topic this module creates for alarm notifications. alarm_emails are subscribed to this topic; any ARNs passed in alarm_topic_arns receive the same alarms in addition to this one."
+  value       = aws_sns_topic.alarms.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -253,10 +253,10 @@ variable "root_volume_size" {
   default     = 30
 }
 
-variable "sns_topic_alarm_arn" {
-  description = "ARN of SNS topic for Cloudwatch alarms on base EC2 instance."
-  type        = string
-  default     = null
+variable "alarm_topic_arns" {
+  description = "List of existing SNS topic ARNs to fan alarm notifications out to (e.g. PagerDuty, Slack, shared org topics). The module always creates its own topic for alarm_emails; this list is additive."
+  type        = list(string)
+  default     = []
 }
 
 variable "subnet_ids" {


### PR DESCRIPTION
Closes #93. Also closes the docs-sidebar regression and the remaining
`docs/examples.md` work from #79.

## Summary

- **Alarms UX fix (#93).** The CPU alarm was gated on the optional
  `sns_topic_alarm_arn`, so callers who used only `alarm_emails` got
  silently no EC2 monitoring. Fixed by adopting the
  `terraform-aws-lambda-monitored` SNS pattern: the module now **always**
  creates its own SNS topic, subscribes `alarm_emails` to it, and routes
  every alarm there.
- **Breaking rename.** `sns_topic_alarm_arn` (singular, optional) →
  `alarm_topic_arns` (list, default `[]`). After the rename, alarms fire
  to the module-owned topic AND to each external ARN. Version bump is
  major — semver discipline.
- **Expanded alarm coverage.** Six new alarms on ASG count metrics and
  custom `GitHubRunners` metrics, including a `RunnerRegistrationGap`
  alarm that catches the exact class of silent failure #93 is about.
- **ASG group-metrics enabled.** Previously `EnabledMetrics = []`, so
  `GroupInServiceInstances` etc. were not emitted. New alarms and
  dashboard would have shown "No data" without this. 1-minute
  granularity is free.
- **CloudWatch dashboard.** One pane of glass named after the ASG;
  grouped into Alarms / GitHub / ASG / Lambda sections with a top-line
  pool-identity markdown (env · labels · region).
- **Docs-site sidebar fix.** `mkdocs.yml` `nav` listed only Home; added
  all 9 pages. Also adds `docs/examples.md` per #79.

## Commits (landed separately for changelog readability)

1. `docs: fix mkdocs sidebar and add examples page`
2. `feat!: adopt lambda-monitored SNS pattern; always create alarm topic (#93)`
3. `feat: expand alarm coverage and add CloudWatch dashboard (#93)`

## Upgrade notes

Callers who previously set `sns_topic_alarm_arn = "<arn>"` must rename:

```hcl
# Before
sns_topic_alarm_arn = "arn:aws:sns:us-east-1:123456789012:shared-alarms"

# After
alarm_topic_arns = ["arn:aws:sns:us-east-1:123456789012:shared-alarms"]
```

Plan will show a new module-owned SNS topic, email subscriptions, six new
alarms, one new dashboard, and `enabled_metrics` added to the ASG. Version
bump: `3.5.0 → 4.0.0`. Use `make release-major`.

## Out of scope (filed as follow-ups)

- Install CloudWatch agent on `role::github_runner` to unlock host-level
  alarms — `infrahouse/puppet-code#270`
- Emit `RegistrationLatencySeconds` from `./config.sh` success path in
  Puppet — `infrahouse/puppet-code#271`
- Spot interruption counter (Lambda + EventBridge) — `#94`

## Test plan

- [ ] `make test-clean` — default selector exercises the `alarm_emails`-only path; asserts module-owned SNS topic, emails subscribed, all alarms wired, dashboard created
- [ ] Manual: apply in `test_data/actions-runner/`, open CloudWatch dashboard via `dashboard_url` output, verify all widgets render with data
- [ ] Manual: verify `EnabledMetrics` populated on the ASG post-apply (was empty before)
- [ ] Migration sanity: caller previously using `sns_topic_alarm_arn` renames to `alarm_topic_arns` and plans cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)