### PR TITLE
Bump lambda-monitored to 1.1.1 for vanta CRR exemption

### DIFF
--- a/modules/record_metric/main.tf
+++ b/modules/record_metric/main.tf
@@ -54,7 +54,7 @@ resource "aws_iam_policy" "record_metric_permissions" {
 # Lambda function with monitoring using terraform-aws-lambda-monitored module
 module "lambda_monitored" {
   source  = "registry.infrahouse.com/infrahouse/lambda-monitored/aws"
-  version = "1.1.0"
+  version = "1.1.1"
 
   function_name                        = "${var.asg_name}_record_metric"
   lambda_source_dir                    = "${path.module}/lambda"

--- a/modules/runner_deregistration/main.tf
+++ b/modules/runner_deregistration/main.tf
@@ -90,7 +90,7 @@ resource "aws_iam_policy" "runner_deregistration_permissions" {
 # Lambda function with monitoring using terraform-aws-lambda-monitored module
 module "lambda_monitored" {
   source  = "registry.infrahouse.com/infrahouse/lambda-monitored/aws"
-  version = "1.1.0"
+  version = "1.1.1"
 
   function_name                        = "${var.asg_name}_deregistration"
   lambda_source_dir                    = "${path.module}/lambda"

--- a/modules/runner_registration/main.tf
+++ b/modules/runner_registration/main.tf
@@ -97,7 +97,7 @@ resource "aws_iam_policy" "runner_registration_permissions" {
 # Lambda function with monitoring using terraform-aws-lambda-monitored module
 module "lambda_monitored" {
   source  = "registry.infrahouse.com/infrahouse/lambda-monitored/aws"
-  version = "1.1.0"
+  version = "1.1.1"
 
   function_name                        = "${var.asg_name}_registration"
   lambda_source_dir                    = "${path.module}/lambda"


### PR DESCRIPTION
## Summary
- Bumps `infrahouse/lambda-monitored/aws` from 1.1.0 to 1.1.1 in all three submodules (`record_metric`, `runner_deregistration`, `runner_registration`)
- v1.1.1 upgrades `infrahouse/s3-bucket/aws` from 0.3.1 to 0.6.0 and adds `vanta-exempt:aws-s3-cross-region-replication-enabled` tag on the lambda zip S3 buckets

Closes #97

## Test plan
- [x] Verify `terraform init` succeeds with the new version
- [x] Verify `terraform plan` shows the expected tag addition on lambda zip buckets
- [x] Run integration tests (`make test-clean`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)