### PR TITLE
fix: pin cryptography floor in lambda deps (GHSA-537c-gmf6-5ccf)

### DIFF
--- a/modules/record_metric/lambda/requirements.txt
+++ b/modules/record_metric/lambda/requirements.txt
@@ -1,1 +1,7 @@
 infrahouse-core ~= 1.0
+
+# Security floor for a transitive dependency (pulled in via infrahouse-core ->
+# PyGithub -> PyJWT). cryptography wheels < 48.0.1 statically link a vulnerable
+# OpenSSL (GHSA-537c-gmf6-5ccf). Floor only -- cryptography bumps its major
+# frequently, so a ~= pin would go stale.
+cryptography >= 48.0.1

--- a/modules/runner_deregistration/lambda/requirements.txt
+++ b/modules/runner_deregistration/lambda/requirements.txt
@@ -1,1 +1,7 @@
 infrahouse-core ~= 1.0
+
+# Security floor for a transitive dependency (pulled in via infrahouse-core ->
+# PyGithub -> PyJWT). cryptography wheels < 48.0.1 statically link a vulnerable
+# OpenSSL (GHSA-537c-gmf6-5ccf). Floor only -- cryptography bumps its major
+# frequently, so a ~= pin would go stale.
+cryptography >= 48.0.1

--- a/modules/runner_registration/lambda/requirements.txt
+++ b/modules/runner_registration/lambda/requirements.txt
@@ -1,1 +1,7 @@
 infrahouse-core ~= 1.0
+
+# Security floor for a transitive dependency (pulled in via infrahouse-core ->
+# PyGithub -> PyJWT). cryptography wheels < 48.0.1 statically link a vulnerable
+# OpenSSL (GHSA-537c-gmf6-5ccf). Floor only -- cryptography bumps its major
+# frequently, so a ~= pin would go stale.
+cryptography >= 48.0.1


### PR DESCRIPTION
## What

Adds a `cryptography >= 48.0.1` floor to all three Lambda `requirements.txt` files (`runner_registration`, `runner_deregistration`, `record_metric`).

## Why

AWS Inspector flagged **GHSA-537c-gmf6-5ccf** (High, CVSS 7.5) — `cryptography` wheels prior to `48.0.1` statically link a vulnerable OpenSSL ([advisory](https://openssl-library.org/news/secadv/20260609.txt)). `cryptography` is pulled into the Lambda packages transitively:

```
infrahouse-core -> PyGithub -> PyJWT -> cryptography
```

so a build can package a vulnerable version even though the lambdas never declare `cryptography` directly. The deployed `..._deregistration` function was packaging `cryptography 48.0.0`.

## Design notes

- **Floor only, no `~=` cap.** `cryptography` bumps its major version frequently (49.x is already out — and a fresh resolve today pulls it). A `~= 48.0` pin would immediately cap us *below* the current secure release. Deliberate exception to the usual "pin to major with `~=`" standard; called out in a comment next to each pin.
- **Also fixed upstream.** [`infrahouse-core >= 1.1.2`](https://github.com/infrahouse/infrahouse-core/releases/tag/v1.1.2) now carries the same floor, so consumers inherit it. These local floors are kept as a belt-and-suspenders safety net: they're path-independent (hold no matter how `cryptography` enters the tree), regression-proof (survive an upstream regression), and keep the CVE remediation next to the affected package for scanners/auditors.
- **Leaf pin over a dep bump.** Deliberately did *not* bump `infrahouse-core` to remediate this — that would couple a security fix to unrelated functional changes. The two floors move for their own reasons.

## Follow-up

- Rebuild/redeploy the Lambdas so the running functions pick up the fixed wheel and Inspector clears `SEC-4028`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)